### PR TITLE
#6 Incremental diff update fails on iOS

### DIFF
--- a/src/ios/CodePush.m
+++ b/src/ios/CodePush.m
@@ -1,4 +1,5 @@
 #import <Cordova/CDV.h>
+#import <Cordova/CDVConfigParser.h>
 #import "CodePush.h"
 
 @implementation CodePush
@@ -210,7 +211,7 @@ NSString* const CurrentPackageManifestName = @"currentPackage.json";
 
 - (NSURL *)getStartPageURLForLocalPackage:(NSString*)packageLocation {
     if (packageLocation) {
-        NSString* startPage = ((CDVViewController *)self.viewController).startPage;
+        NSString* startPage = [self getConfigLaunchUrl];
         NSString* libraryLocation = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];
         NSArray* realLocationArray = @[libraryLocation, @"NoCloud", packageLocation, @"www", startPage];
         NSString* realStartPageLocation = [NSString pathWithComponents:realLocationArray];
@@ -220,6 +221,19 @@ NSString* const CurrentPackageManifestName = @"currentPackage.json";
     }
     
     return nil;
+}
+
+- (NSString*)getConfigLaunchUrl
+{
+    CDVConfigParser* delegate = [[CDVConfigParser alloc] init];
+    NSString* configPath = [[NSBundle mainBundle] pathForResource:@"config" ofType:@"xml"];
+    NSURL* configUrl = [NSURL fileURLWithPath:configPath];
+    
+    NSXMLParser* configParser = [[NSXMLParser alloc] initWithContentsOfURL:configUrl];
+    [configParser setDelegate:((id < NSXMLParserDelegate >)delegate)];
+    [configParser parse];
+    
+    return delegate.startPage;
 }
 
 - (void)redirectStartPageToURL:(NSString*)packageLocation{


### PR DESCRIPTION
The issue was caused by the fact that we were using the absolute path of the start page instead of the relative path for constructing the start page URL for new packages.It was fixed by reading the start page from config.xml, which is relative to the www folder and consistent with the Android platform implementation.

@nisheetjain @itsananderson @silhouettes @hinzo @itsananderson 
