### PR TITLE
Bug fix

### DIFF
--- a/src/ios/CodePush.m
+++ b/src/ios/CodePush.m
@@ -102,7 +102,14 @@ NSString* const CurrentPackageManifestName = @"currentPackage.json";
 
 - (void)sendResultForPreference:(NSString*)preferenceName command:(CDVInvokedUrlCommand*)command {
     NSString* preferenceValue = ((CDVViewController *)self.viewController).settings[preferenceName];
-    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:preferenceValue];
+    // length of NIL is zero
+    CDVPluginResult* pluginResult;
+    if ([preferenceValue length] > 0) {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:preferenceValue];
+    } else {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[NSString stringWithFormat:@"Could not find preference %@", preferenceName]];
+    }
+    
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 


### PR DESCRIPTION
Fixed an issue on iOS where the empty string was returned when the user did not specify the server URL in config.xml instead of the default value.

@nisheetjain @dtivel @hinzo @itsananderson 
