### PR TITLE
Updated type definition file.

### DIFF
--- a/typings/codePush.d.ts
+++ b/typings/codePush.d.ts
@@ -98,6 +98,25 @@ interface ILocalPackage extends IPackage {
 }
 
 /**
+ * Decomposed static side of RemotePackage.
+ * For Class Decomposition guidelines see http://www.typescriptlang.org/Handbook#writing-dts-files-guidelines-and-specifics
+ */
+interface RemotePackage_Static {
+    new (): IRemotePackage;
+}
+
+/**
+ * Decomposed static side of LocalPackage.
+ * For Class Decomposition guidelines see http://www.typescriptlang.org/Handbook#writing-dts-files-guidelines-and-specifics
+ */
+interface LocalPackage_Static {
+    new (): ILocalPackage;
+}
+
+declare var RemotePackage: RemotePackage_Static;
+declare var LocalPackage: LocalPackage_Static;
+
+/**
  * Defines the JSON format of the current package information file.
  * This file is stored in the local storage of the device and persists between store updates and code-push updates.
  * 


### PR DESCRIPTION
Added support for easily constructing LocalPackage and RemotePackage objects. Consumers can now do this without casting:

``` typescript
var remotePackage: IRemotePackage = new RemotePackage();
remotePackage.deploymentKey = "12345";
remotePackage.download();
```
