### PR TITLE
Bumped version to 1.1.0-beta.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-code-push",
-  "version": "1.0.1-beta",
+  "version": "1.1.0-beta",
   "description": "CodePush Plugin for Apache Cordova",
   "cordova": {
     "id": "cordova-plugin-code-push",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-    <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-code-push" version="1.0.1-beta">
+    <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-code-push" version="1.1.0-beta">
         <name>CodePush</name>
         <description>CodePush Plugin for Apache Cordova</description>
         <license>MIT</license>

--- a/samples/advanced/config.xml
+++ b/samples/advanced/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-    <widget id="io.cordova.hellocodepush.advanced" version="1.0.1-beta" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <widget id="io.cordova.hellocodepush.advanced" version="1.1.0-beta" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
         <name>CodePushAdvanced</name>
         <description>
             A sample Apache Cordova application that uses the CodePush service.
@@ -9,7 +9,7 @@
         <content src="index.html" />
 
         <plugin name="cordova-plugin-whitelist" version="1" />
-        <plugin name="cordova-plugin-code-push" version="1.0.1-beta" />
+        <plugin name="cordova-plugin-code-push" version="1.1.0-beta" />
         <plugin name="cordova-plugin-dialogs" version="1.1.1" />
 
         <!-- This sample application can communicate with any external domain.

--- a/samples/basic/config.xml
+++ b/samples/basic/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-    <widget id="io.cordova.hellocodepush.basic" version="1.0.1-beta" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <widget id="io.cordova.hellocodepush.basic" version="1.1.0-beta" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
         <name>CodePushBasic</name>
         <description>
             A sample Apache Cordova application that uses the CodePush service.
@@ -9,7 +9,7 @@
         <content src="index.html" />
 
         <plugin name="cordova-plugin-whitelist" version="1" />
-        <plugin name="cordova-plugin-code-push" version="1.0.1-beta" />
+        <plugin name="cordova-plugin-code-push" version="1.1.0-beta" />
         <plugin name="cordova-plugin-dialogs" version="1.1.1" />
 
         <!-- This sample application can communicate with any external domain.

--- a/test/template/config.xml
+++ b/test/template/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-    <widget id="io.cordova.test.codepush" version="1.0.1-beta" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <widget id="io.cordova.test.codepush" version="1.1.0-beta" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
         <name>CodePushTest</name>
         <description>
             A sample Apache Cordova application that is used for testing the CodePush plugin.


### PR DESCRIPTION
I did not bump the dependency version of code-push, since in the latest release the [plugin.xml version was not increased](https://github.com/Microsoft/code-push/blob/master/sdk/plugin.xml#L2). This is okay for now since the acquisition code was not changed. We will bump all versions in the next release.

@lostintangent @geof90 @dtivel @silhouettes @nisheetjain 