### PR TITLE
Changing plugin.xml description

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
     <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-code-push" version="1.1.0-beta">
         <name>CodePush</name>
-        <description>CodePush Plugin for Apache Cordova</description>
+        <description>This plugins allows you to push code updates to your apps, instantly, using the CodePush service</description>
         <license>MIT</license>
         <keywords>cordova,code,push</keywords>
         <repo>https://github.com/Microsoft/cordova-plugin-code-push.git</repo>


### PR DESCRIPTION
Adding a little more description to the plugin.xml file. I'm leaving the package.json description as-is, since on NPM, the entire readme is already displayed, and the current description helps make it clear that the module is a Cordova plugin.

For Cordova consumers (e.g. Visual Studio), the plugin is obviously for Cordova, so having the description provide a little context on what it is for, seems helpful. I'm using a variant of the slogan from the homepage, based on the recommendation from Amanda.