### PR TITLE
Prepare command for updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,13 @@ The JavaScript code in this plugin is compiled from TypeScript. Please see [this
 ## Create an application update package
 You can create an update by simply zipping and deploying your platform's www folder. The [CodePush CLI](https://github.com/Microsoft/code-push/tree/master/cli) has a ```deploy``` command for this.
 
-1. Build your application
+1. Prepare your application
 
   ```
-  cordova build
+  cordova prepare
   ```
+  We are not deploying binaries in updates, so `prepare` is enough for this step. The `cordova build` command works as well for this step, since it calls `cordova prepare` behind the scenes.
+  
 2. Deploy update using the [CodePush CLI](https://github.com/Microsoft/code-push/tree/master/cli)
 
   - For Android:

--- a/test/projectManager.ts
+++ b/test/projectManager.ts
@@ -118,6 +118,13 @@ export class ProjectManager {
     public static buildPlatform(projectFolder: string, targetPlatform: platform.IPlatform): Q.Promise<void> {
         return ProjectManager.execAndLogChildProcess("cordova build " + targetPlatform.getCordovaName(), { cwd: projectFolder });
     }
+    
+    /**
+     * Prepares a specific platform of a Cordova project. 
+     */
+    public static preparePlatform(projectFolder: string, targetPlatform: platform.IPlatform): Q.Promise<void> {
+        return ProjectManager.execAndLogChildProcess("cordova prepare " + targetPlatform.getCordovaName(), { cwd: projectFolder });
+    }
 
     /**
      * Runs a project to a given target / platform.

--- a/test/test.ts
+++ b/test/test.ts
@@ -139,7 +139,7 @@ function setupUpdateProject(scenarioPath: string, version: string): Q.Promise<vo
         .then<void>(() => { return projectManager.addPlatform(updatesDirectory, targetPlatform); })
         .then<void>(() => { return projectManager.addPlugin(testRunDirectory, AcquisitionSDKPluginName); })
         .then<void>(() => { return projectManager.addPlugin(updatesDirectory, thisPluginPath); })
-        .then<void>(() => { return projectManager.buildPlatform(updatesDirectory, targetPlatform); });
+        .then<void>(() => { return projectManager.preparePlatform(updatesDirectory, targetPlatform); });
 };
 
 function verifyMessages(expectedMessages: (string | su.AppMessage)[], deferred: Q.Deferred<void>): (requestBody: any) => void {


### PR DESCRIPTION
Changed tests and documentation to use prepare instead of build for updates. This simplifies update creation and significantly reduces test run time.

Thanks @lostintangent!

@dtivel @silhouettes @geof90 @nisheetjain 