### PR TITLE
Update fileTransfer.d.ts

### DIFF
--- a/typings/fileTransfer.d.ts
+++ b/typings/fileTransfer.d.ts
@@ -93,13 +93,13 @@ interface FileUploadOptions {
     /** Whether to upload the data in chunked streaming mode. Defaults to true. */
     chunkedMode?: boolean;
     /** A map of header name/header values. Use an array to specify more than one value. */
-    headers?: Object[];
+    headers?: Object
 }
 
 /** Optional parameters for download method. */
 interface FileDownloadOptions {
     /** A map of header name/header values. Use an array to specify more than one value. */
-    headers?: Object[];
+    headers?: Object;
 }
 
 /** A FileTransferError object is passed to an error callback when an error occurs. */

--- a/typings/fileTransfer.d.ts
+++ b/typings/fileTransfer.d.ts
@@ -93,7 +93,7 @@ interface FileUploadOptions {
     /** Whether to upload the data in chunked streaming mode. Defaults to true. */
     chunkedMode?: boolean;
     /** A map of header name/header values. Use an array to specify more than one value. */
-    headers?: Object
+    headers?: Object;
 }
 
 /** Optional parameters for download method. */


### PR DESCRIPTION
Fixing incorrect typings in the fileTransfer.d.ts (https://github.com/Microsoft/cordova-plugin-code-push/issues/65)

Both of these interfaces are defined as taking headers as an object array, but this is incorrect.
Quickly checking https://github.com/apache/cordova-plugin-file-transfer/blob/master/src/android/FileTransfer.java shows that they both take headers as a single object and not an array.

@dlebu @lostintangent 