### PR TITLE
Adding more logging

### DIFF
--- a/bin/www/codePush.js
+++ b/bin/www/codePush.js
@@ -80,7 +80,7 @@ var CodePush = (function () {
                     };
                     if (remotePackageOrUpdateNotification) {
                         if (remotePackageOrUpdateNotification.updateAppVersion) {
-                            CodePushUtil.logMessage("An update is available, but it is targetting a newer binary version than you are currently running.");
+                            CodePushUtil.logMessage("An update is available, but it is targeting a newer binary version than you are currently running.");
                             appUpToDate();
                         }
                         else {

--- a/bin/www/localPackage.js
+++ b/bin/www/localPackage.js
@@ -27,7 +27,7 @@ var LocalPackage = (function (_super) {
     LocalPackage.prototype.install = function (installSuccess, errorCallback, installOptions) {
         var _this = this;
         try {
-            CodePushUtil.logMessage("Installing update package ...");
+            CodePushUtil.logMessage("Installing update");
             if (!installOptions) {
                 installOptions = LocalPackage.getDefaultInstallOptions();
             }

--- a/bin/www/remotePackage.js
+++ b/bin/www/remotePackage.js
@@ -27,7 +27,7 @@ var RemotePackage = (function (_super) {
     RemotePackage.prototype.download = function (successCallback, errorCallback, downloadProgress) {
         var _this = this;
         try {
-            CodePushUtil.logMessage("Downloading update package");
+            CodePushUtil.logMessage("Downloading update");
             if (!this.downloadUrl) {
                 CodePushUtil.invokeErrorCallback(new Error("The remote package does not contain a download URL."), errorCallback);
             }

--- a/bin/www/remotePackage.js
+++ b/bin/www/remotePackage.js
@@ -27,7 +27,7 @@ var RemotePackage = (function (_super) {
     RemotePackage.prototype.download = function (successCallback, errorCallback, downloadProgress) {
         var _this = this;
         try {
-            CodePushUtil.logMessage("Downloading update package ...");
+            CodePushUtil.logMessage("Downloading update package");
             if (!this.downloadUrl) {
                 CodePushUtil.invokeErrorCallback(new Error("The remote package does not contain a download URL."), errorCallback);
             }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -142,7 +142,7 @@ gulp.task("test-ios-wkwebview", function (callback) {
 
 gulp.task("test-android", function (callback) {
     var command = "mocha";
-    var args = ["./bin/test", "--mockserver", "http://10.0.2.2:3000", "--platform", "android"];
+    var args = ["./bin/test", "--mockserver", "http://10.0.2.2:3000", "--platform", "android", "--use-wkwebview", "false"];
     executeCommand(command, args, callback);
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -142,7 +142,7 @@ gulp.task("test-ios-wkwebview", function (callback) {
 
 gulp.task("test-android", function (callback) {
     var command = "mocha";
-    var args = ["./bin/test", "--mockserver", "http://10.0.2.2:3000", "--platform", "android", "--use-wkwebview", "false"];
+    var args = ["./bin/test", "--mockserver", "http://10.0.2.2:3000", "--platform", "android"];
     executeCommand(command, args, callback);
 });
 

--- a/test/testUtil.ts
+++ b/test/testUtil.ts
@@ -39,7 +39,8 @@ export class TestUtil {
      * Reads if we should use the WkWebView or the UIWebView
      */
     public static readShouldUseWkWebView(): boolean {
-        return JSON.parse(TestUtil.readMochaCommandLineOption(TestUtil.SHOULD_USE_WKWEBVIEW) || "false");
+        var shouldUseWkWebView = TestUtil.readMochaCommandLineOption(TestUtil.SHOULD_USE_WKWEBVIEW);
+        return shouldUseWkWebView ? JSON.parse(shouldUseWkWebView) : false;
     }
 
 	/**

--- a/test/testUtil.ts
+++ b/test/testUtil.ts
@@ -39,7 +39,7 @@ export class TestUtil {
      * Reads if we should use the WkWebView or the UIWebView
      */
     public static readShouldUseWkWebView(): boolean {
-        return JSON.parse(TestUtil.readMochaCommandLineOption(TestUtil.SHOULD_USE_WKWEBVIEW));
+        return JSON.parse(TestUtil.readMochaCommandLineOption(TestUtil.SHOULD_USE_WKWEBVIEW) || "false");
     }
 
 	/**

--- a/www/codePush.ts
+++ b/www/codePush.ts
@@ -140,7 +140,7 @@ class CodePush implements CodePushCordovaPlugin {
                     if (remotePackageOrUpdateNotification) {
                         if ((<NativeUpdateNotification>remotePackageOrUpdateNotification).updateAppVersion) {
                             /* There is an update available for a different version. In the current version of the plugin, we treat that as no update. */
-                            CodePushUtil.logMessage("An update is available, but it is targetting a newer binary version than you are currently running.");
+                            CodePushUtil.logMessage("An update is available, but it is targeting a newer binary version than you are currently running.");
                             appUpToDate();
                         } else {
                             /* There is an update available for the current version. */

--- a/www/codePush.ts
+++ b/www/codePush.ts
@@ -133,13 +133,14 @@ class CodePush implements CodePushCordovaPlugin {
                 }
                 else {
                     var appUpToDate = () => {
-                        CodePushUtil.logMessage("The application is up to date.");
+                        CodePushUtil.logMessage("App is up to date.");
                         querySuccess && querySuccess(null);
                     };
 
                     if (remotePackageOrUpdateNotification) {
                         if ((<NativeUpdateNotification>remotePackageOrUpdateNotification).updateAppVersion) {
                             /* There is an update available for a different version. In the current version of the plugin, we treat that as no update. */
+                            CodePushUtil.logMessage("An update is available, but it is targetting a newer binary version than you are currently running.");
                             appUpToDate();
                         } else {
                             /* There is an update available for the current version. */
@@ -171,6 +172,7 @@ class CodePush implements CodePushCordovaPlugin {
                     CodePushUtil.invokeErrorCallback(initError, queryError);
                 } else {
                     LocalPackage.getCurrentOrDefaultPackage((localPackage: LocalPackage) => {
+                        CodePushUtil.logMessage("Checking for update.");
                         acquisitionManager.queryUpdateWithCurrentPackage(localPackage, callback);
                     }, (error: Error) => {
                         CodePushUtil.invokeErrorCallback(error, queryError);
@@ -235,6 +237,16 @@ class CodePush implements CodePushCordovaPlugin {
         };
 
         var onInstallSuccess = () => {
+            switch (syncOptions.installMode) {
+                case InstallMode.ON_NEXT_RESTART:
+                    CodePushUtil.logMessage("Update is installed and will be run on the next app restart.");
+                    break;
+                    
+                case InstallMode.ON_NEXT_RESUME:
+                    CodePushUtil.logMessage("Update is installed and will be run when the app next resumes.");
+                    break;
+            }
+            
             syncCallback && syncCallback(SyncStatus.UPDATE_INSTALLED);
         };
 
@@ -249,11 +261,17 @@ class CodePush implements CodePushCordovaPlugin {
         };
 
         var onUpdate = (remotePackage: RemotePackage) => {
-            if (!remotePackage || (remotePackage.failedInstall && syncOptions.ignoreFailedUpdates)) {
+            var updateShouldBeIgnored = remotePackage && (remotePackage.failedInstall && syncOptions.ignoreFailedUpdates);
+            if (!remotePackage || updateShouldBeIgnored) {
+                if (updateShouldBeIgnored) {
+                    CodePushUtil.logMessage("An update is available, but it is being ignored due to have been previously rolled back.");
+                }
+                
                 syncCallback && syncCallback(SyncStatus.UP_TO_DATE);
             } else {
                 var dlgOpts: UpdateDialogOptions = <UpdateDialogOptions>syncOptions.updateDialog;
                 if (dlgOpts) {
+                    CodePushUtil.logMessage("Awaiting user action.");
                     syncCallback && syncCallback(SyncStatus.AWAITING_USER_ACTION);
                 }
                 if (remotePackage.isMandatory && syncOptions.updateDialog) {
@@ -273,6 +291,7 @@ class CodePush implements CodePushCordovaPlugin {
                             case 2:
                             default:
                                 /* Cancel */
+                                CodePushUtil.logMessage("User cancelled the update.");
                                 syncCallback && syncCallback(SyncStatus.UPDATE_IGNORED);
                                 break;
                         }

--- a/www/localPackage.ts
+++ b/www/localPackage.ts
@@ -51,7 +51,7 @@ class LocalPackage extends Package implements ILocalPackage {
      */
     public install(installSuccess: SuccessCallback<void>, errorCallback?: ErrorCallback, installOptions?: InstallOptions) {
         try {
-            CodePushUtil.logMessage("Installing update package ...");
+            CodePushUtil.logMessage("Installing update");
 
             if (!installOptions) {
                 installOptions = LocalPackage.getDefaultInstallOptions();

--- a/www/remotePackage.ts
+++ b/www/remotePackage.ts
@@ -32,7 +32,7 @@ class RemotePackage extends Package implements IRemotePackage {
      */
     public download(successCallback: SuccessCallback<LocalPackage>, errorCallback?: ErrorCallback, downloadProgress?: SuccessCallback<DownloadProgress>): void {
         try {
-            CodePushUtil.logMessage("Downloading update package ...");
+            CodePushUtil.logMessage("Downloading update package");
             if (!this.downloadUrl) {
                 CodePushUtil.invokeErrorCallback(new Error("The remote package does not contain a download URL."), errorCallback);
             } else {

--- a/www/remotePackage.ts
+++ b/www/remotePackage.ts
@@ -32,7 +32,7 @@ class RemotePackage extends Package implements IRemotePackage {
      */
     public download(successCallback: SuccessCallback<LocalPackage>, errorCallback?: ErrorCallback, downloadProgress?: SuccessCallback<DownloadProgress>): void {
         try {
-            CodePushUtil.logMessage("Downloading update package");
+            CodePushUtil.logMessage("Downloading update");
             if (!this.downloadUrl) {
                 CodePushUtil.invokeErrorCallback(new Error("The remote package does not contain a download URL."), errorCallback);
             } else {


### PR DESCRIPTION
This PR updates some existing log messages to remove the use of the word "package" and be more consistent with the RN plugin logs. Additionally, I introduced new logs for the following scenarios:

1. Checking for an update, this way, a dev can see this is occurring, as opposed to needing to wait for the check to complete and display the up-to-date or update-available message

2. After an update is installed, we display a log indicating when it will be applied.

3. If an available update is being ignored due to having been blacklisted.

4. When displaying an update prompt, and if the user cancelled/ignored it.

5. If an available update is being ignored due to it targeting a newer binary version.

Additionally, this includes the JS files for #77, which I forgot to check-in.