### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
-#built by npm install
+#ignore the files built by npm install
 node_modules/*
 
-#built by building the project
-bin/*
-#keep the javascript files compiled from the project (but not those from the tests)
-!bin/www/*
+#ignore the compiled test files
+bin/test/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #built by npm install
-node_modules\*
+node_modules/*
 
 #built by building the project
-bin\*
+bin/*
 #keep the javascript files compiled from the project (but not those from the tests)
-!bin\www\*
+!bin/www/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+#built by npm install
+node_modules\*
+
+#built by building the project
+bin\*
+#keep the javascript files compiled from the project (but not those from the tests)
+!bin\www\*


### PR DESCRIPTION
Previously, there was no .gitignore file in the repo, so whenever you would build, about 6 thousand changed files would appear in GitHub for Windows. This is incredibly cluttery and slow, so I added a .gitignore that ignores files in node_modules, which are built by "npm install", and files in bin/test, which are built by "gulp" for testing purposes