### PR TITLE
Fix build warning

### DIFF
--- a/src/ios/UpdateHashUtils.m
+++ b/src/ios/UpdateHashUtils.m
@@ -1,4 +1,5 @@
-#include <CommonCrypto/CommonDigest.h>
+#import <CommonCrypto/CommonDigest.h>
+#import "UpdateHashUtils.h"
 
 @implementation UpdateHashUtils : NSObject
 


### PR DESCRIPTION
This PR simply fixes a build warning on iOS. It doesn't impact the app at all, but it may cause concern for users and it introduces unnecessary noise in the build output.

<img width="763" alt="screen shot 2016-04-20 at 4 02 53 pm" src="https://cloud.githubusercontent.com/assets/116461/14693238/f722e0f0-0711-11e6-8647-8d12fd1fc508.png">