### PR TITLE
Fix timing issue with reporting status

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "peerDependencies": {
     "code-push": ">=1.8.0-beta",
     "cordova-plugin-file-transfer": ">=1.3.0",
-    "cordova-plugin-file": ">=3.0.0",
+    "cordova-plugin-file": "^3.0.0",
     "cordova-plugin-zip": ">=3.0.0",
     "cordova-plugin-dialogs": ">=1.1.1",
     "cordova-plugin-device": ">=1.1.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "peerDependencies": {
     "code-push": ">=1.8.0-beta",
     "cordova-plugin-file-transfer": ">=1.3.0",
-    "cordova-plugin-file": "^3.0.0",
+    "cordova-plugin-file": ">=3.0.0",
     "cordova-plugin-zip": ">=3.0.0",
     "cordova-plugin-dialogs": ">=1.1.1",
     "cordova-plugin-device": ">=1.1.0"

--- a/src/android/CodePushReportingManager.java
+++ b/src/android/CodePushReportingManager.java
@@ -48,7 +48,7 @@ public class CodePushReportingManager {
         /* JS function to call: window.codePush.reportStatus(status: number, label: String, appVersion: String, currentDeploymentKey: String, previousLabelOrAppVersion?: string, previousDeploymentKey?: string) */
         final String script = String.format(
             Locale.US,
-            "javascript:window.codePush.reportStatus(%d, %s, %s, %s, %s, %s)",
+            "javascript:document.addEventListener(\"deviceready\", reportStatus); function reportStatus() { window.codePush.reportStatus(%d, %s, %s, %s, %s, %s); }",
             status.getValue(),
             convertStringParameter(label),
             convertStringParameter(appVersion),

--- a/src/android/CodePushReportingManager.java
+++ b/src/android/CodePushReportingManager.java
@@ -48,7 +48,7 @@ public class CodePushReportingManager {
         /* JS function to call: window.codePush.reportStatus(status: number, label: String, appVersion: String, currentDeploymentKey: String, previousLabelOrAppVersion?: string, previousDeploymentKey?: string) */
         final String script = String.format(
             Locale.US,
-            "javascript:document.addEventListener(\"deviceready\", reportStatus); function reportStatus() { window.codePush.reportStatus(%d, %s, %s, %s, %s, %s); }",
+            "javascript:document.addEventListener(\"deviceready\", function () { window.codePush.reportStatus(%d, %s, %s, %s, %s, %s); });",
             status.getValue(),
             convertStringParameter(label),
             convertStringParameter(appVersion),

--- a/src/ios/CodePushReportingManager.m
+++ b/src/ios/CodePushReportingManager.m
@@ -22,7 +22,7 @@ const NSString* LastVersionLabelOrAppVersionKey = @"LAST_VERSION_LABEL_OR_APP_VE
         }
 
         /* JS function to call: window.codePush.reportStatus(status: number, label: String, appVersion: String, deploymentKey: String) */
-        NSString* script = [NSString stringWithFormat:@"window.codePush.reportStatus(%i, %@, %@, %@, %@, %@)", (int)status, labelParameter, appVersionParameter, deploymentKeyParameter, lastVersionLabelOrAppVersionParameter, lastVersionDeploymentKeyParameter];
+        NSString* script = [NSString stringWithFormat:@"document.addEventListener(\"deviceready\", function () { window.codePush.reportStatus(%d, %s, %s, %s, %s, %s); });", (int)status, labelParameter, appVersionParameter, deploymentKeyParameter, lastVersionLabelOrAppVersionParameter, lastVersionDeploymentKeyParameter];
         if ([webView respondsToSelector:@selector(evaluateJavaScript:completionHandler:)]) {
             [webView performSelector:@selector(evaluateJavaScript:completionHandler:) withObject:script withObject: NULL];
         } else if ([webView isKindOfClass:[UIWebView class]]) {

--- a/test/platform.ts
+++ b/test/platform.ts
@@ -3,7 +3,7 @@
 "use strict";
 
 import path = require("path");
-import ProjectManager = require("./ProjectManager");
+import ProjectManager = require("./projectManager");
 import tu = require("./testUtil");
 import Q = require("q");
 


### PR DESCRIPTION
Fixes an issue with dependcy versions that could prevent an "npm install" from working correctly.
Fixes a reference case sensitivity issue in one of the test files.
Wraps reportStatus from native in a deviceready listener to prevent it from being called before codePush object is ready.

Should address issue https://github.com/Microsoft/cordova-plugin-code-push/issues/103

@lostintangent @dlebu @geof90 