### PR TITLE
Fix nil deploymentkey crash

### DIFF
--- a/bin/www/codePush.js
+++ b/bin/www/codePush.js
@@ -18,8 +18,8 @@ var SyncStatus = require("./syncStatus");
 var CodePush = (function () {
     function CodePush() {
     }
-    CodePush.prototype.notifyApplicationReady = function (notifySucceeded, notifyFailed) {
-        cordova.exec(notifySucceeded, notifyFailed, "CodePush", "updateSuccess", []);
+    CodePush.prototype.notifyApplicationReady = function (notifySucceeded, notifyFailed, deploymentKey) {
+        cordova.exec(notifySucceeded, notifyFailed, "CodePush", "updateSuccess", [deploymentKey]);
     };
     CodePush.prototype.restartApplication = function (installSuccess, errorCallback) {
         cordova.exec(installSuccess, errorCallback, "CodePush", "restartApplication", []);
@@ -179,7 +179,7 @@ var CodePush = (function () {
             var defaultOptions = this.getDefaultSyncOptions();
             CodePushUtil.copyUnassignedMembers(defaultOptions, syncOptions);
         }
-        window.codePush.notifyApplicationReady();
+        window.codePush.notifyApplicationReady(null, null, syncOptions.deploymentKey);
         var onError = function (error) {
             CodePushUtil.logError("An error occurred during sync.", error);
             syncCallback && syncCallback(SyncStatus.ERROR);

--- a/src/android/CodePush.java
+++ b/src/android/CodePush.java
@@ -63,7 +63,7 @@ public class CodePush extends CordovaPlugin {
         } else if ("install".equals(action)) {
             return execInstall(args, callbackContext);
         } else if ("updateSuccess".equals(action)) {
-            return execUpdateSuccess(callbackContext);
+            return execUpdateSuccess(args, callbackContext);
         } else if ("restartApplication".equals(action)) {
             return execRestartApplication(args, callbackContext);
         } else if ("isPendingUpdate".equals(action)) {
@@ -103,13 +103,18 @@ public class CodePush extends CordovaPlugin {
         return true;
     }
 
-    private boolean execUpdateSuccess(CallbackContext callbackContext) {
+    private boolean execUpdateSuccess(CordovaArgs args, CallbackContext callbackContext) {
+        String deploymentKey = args.getString(0);
+        if (deploymentKey.equals(null) || string.equals("") || string.equals("null")) {
+            deploymentKey = mainWebView.getPreferences().getString(DEPLOYMENT_KEY_PREFERENCE, null);
+        }
+
         if (this.codePushPackageManager.isFirstRun()) {
             this.codePushPackageManager.saveFirstRunFlag();
             /* save reporting status for first install */
             try {
                 String appVersion = Utilities.getAppVersionName(cordova.getActivity());
-                codePushReportingManager.reportStatus(CodePushReportingManager.Status.STORE_VERSION, null, appVersion, mainWebView.getPreferences().getString(DEPLOYMENT_KEY_PREFERENCE, null), this.mainWebView);
+                codePushReportingManager.reportStatus(CodePushReportingManager.Status.STORE_VERSION, null, appVersion, deploymentKey, this.mainWebView);
             } catch (PackageManager.NameNotFoundException e) {
                 // Should not happen unless the appVersion is not specified, in which case we can't report anything anyway.
                 e.printStackTrace();
@@ -310,13 +315,6 @@ public class CodePush extends CordovaPlugin {
                             this.codePushPackageManager.clearFailedUpdates();
                             this.codePushPackageManager.clearPendingInstall();
                             this.codePushPackageManager.clearInstallNeedsConfirmation();
-                            try {
-                                String appVersion = Utilities.getAppVersionName(cordova.getActivity());
-                                codePushReportingManager.reportStatus(CodePushReportingManager.Status.STORE_VERSION, null, appVersion, mainWebView.getPreferences().getString(DEPLOYMENT_KEY_PREFERENCE, null), this.mainWebView);
-                            } catch (PackageManager.NameNotFoundException e) {
-                                // Should not happen unless the appVersion is not specified, in which case we can't report anything anyway.
-                                e.printStackTrace();
-                            }
                         }
                     }
                 }

--- a/src/android/CodePush.java
+++ b/src/android/CodePush.java
@@ -104,8 +104,14 @@ public class CodePush extends CordovaPlugin {
     }
 
     private boolean execUpdateSuccess(CordovaArgs args, CallbackContext callbackContext) {
-        String deploymentKey = args.getString(0);
-        if (deploymentKey.equals(null) || string.equals("") || string.equals("null")) {
+        String deploymentKey = "";
+        try {
+            deploymentKey = args.getString(0);
+        } catch (JSONException e) {
+            // no-op becuase we don't care if we didn't get a deployment key from script; we will just try to use the one from preferences
+        }
+
+        if (deploymentKey.equals(null) || deploymentKey.equals("") || deploymentKey.equals("null") || deploymentKey.equals("undefined")) {
             deploymentKey = mainWebView.getPreferences().getString(DEPLOYMENT_KEY_PREFERENCE, null);
         }
 

--- a/src/ios/CodePush.m
+++ b/src/ios/CodePush.m
@@ -58,10 +58,14 @@ const NSString* DeploymentKeyPreference = @"codepushdeploymentkey";
 }
 
 - (void)updateSuccess:(CDVInvokedUrlCommand *)command {
+    NSString* deploymentKey = [command argumentAtIndex:0 withDefault:nil andClass:[NSString class]];
+    if ([deploymentKey length] == 0) {
+        deploymentKey = ((CDVViewController *)self.viewController).settings[DeploymentKeyPreference];
+    }
+
     if ([CodePushPackageManager isFirstRun]) {
         [CodePushPackageManager markFirstRunFlag];
         NSString *appVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
-        NSString *deploymentKey = ((CDVViewController *)self.viewController).settings[DeploymentKeyPreference];
         [CodePushReportingManager reportStatus:STORE_VERSION withLabel:nil version:appVersion deploymentKey:deploymentKey webView:self.webView];
     }
 
@@ -208,9 +212,6 @@ const NSString* DeploymentKeyPreference = @"codepushdeploymentkey";
                 [CodePushPackageManager clearFailedUpdates];
                 [CodePushPackageManager clearPendingInstall];
                 [CodePushPackageManager clearInstallNeedsConfirmation];
-                NSString *appVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
-                NSString *deploymentKey = ((CDVViewController *)self.viewController).settings[DeploymentKeyPreference];
-                [CodePushReportingManager reportStatus:STORE_VERSION withLabel:nil version:appVersion deploymentKey:deploymentKey webView:self.webView];
             }
         }
     }

--- a/typings/codePush.d.ts
+++ b/typings/codePush.d.ts
@@ -187,11 +187,11 @@ interface CodePushCordovaPlugin {
      * Calling this function is required on the first run after an update. On every subsequent application run, calling this function is a noop.
      * If using sync API, calling this function is not required since sync calls it internally.
      *
-     * @param deploymentKey Optional string deployment key for this package.
      * @param notifySucceeded Optional callback invoked if the plugin was successfully notified.
      * @param notifyFailed Optional callback invoked in case of an error during notifying the plugin.
+     * @param deploymentKey Optional deployment key that overrides the config.xml setting.
      */
-    notifyApplicationReady(deploymentKey?: string, notifySucceeded?: SuccessCallback<void>, notifyFailed?: ErrorCallback): void;
+    notifyApplicationReady(notifySucceeded?: SuccessCallback<void>, notifyFailed?: ErrorCallback, deploymentKey?: string): void;
 
     /**
      * Reloads the application. If there is a pending update package installed using ON_NEXT_RESTART or ON_NEXT_RESUME modes, the update

--- a/typings/codePush.d.ts
+++ b/typings/codePush.d.ts
@@ -187,10 +187,11 @@ interface CodePushCordovaPlugin {
      * Calling this function is required on the first run after an update. On every subsequent application run, calling this function is a noop.
      * If using sync API, calling this function is not required since sync calls it internally.
      *
+     * @param deploymentKey Optional string deployment key for this package.
      * @param notifySucceeded Optional callback invoked if the plugin was successfully notified.
      * @param notifyFailed Optional callback invoked in case of an error during notifying the plugin.
      */
-    notifyApplicationReady(notifySucceeded?: SuccessCallback<void>, notifyFailed?: ErrorCallback): void;
+    notifyApplicationReady(deploymentKey?: string, notifySucceeded?: SuccessCallback<void>, notifyFailed?: ErrorCallback): void;
 
     /**
      * Reloads the application. If there is a pending update package installed using ON_NEXT_RESTART or ON_NEXT_RESUME modes, the update

--- a/www/codePush.ts
+++ b/www/codePush.ts
@@ -43,11 +43,12 @@ class CodePush implements CodePushCordovaPlugin {
      * Calling this function is required on the first run after an update. On every subsequent application run, calling this function is a noop.
      * If using sync API, calling this function is not required since sync calls it internally.
      *
+     * @param deploymentKey Optional string deployment key for this package.
      * @param notifySucceeded Optional callback invoked if the plugin was successfully notified.
      * @param notifyFailed Optional callback invoked in case of an error during notifying the plugin.
      */
-    public notifyApplicationReady(notifySucceeded?: SuccessCallback<void>, notifyFailed?: ErrorCallback): void {
-        cordova.exec(notifySucceeded, notifyFailed, "CodePush", "updateSuccess", []);
+    public notifyApplicationReady(deploymentKey?: string, notifySucceeded?: SuccessCallback<void>, notifyFailed?: ErrorCallback): void {
+        cordova.exec(notifySucceeded, notifyFailed, "CodePush", "updateSuccess", [deploymentKey]);
     }
 
     /**
@@ -293,7 +294,7 @@ class CodePush implements CodePushCordovaPlugin {
             CodePushUtil.copyUnassignedMembers(defaultOptions, syncOptions);
         }
 
-        window.codePush.notifyApplicationReady();
+        window.codePush.notifyApplicationReady(syncOptions.deploymentKey);
 
         var onError = (error: Error) => {
             CodePushUtil.logError("An error occurred during sync.", error);

--- a/www/codePush.ts
+++ b/www/codePush.ts
@@ -43,11 +43,11 @@ class CodePush implements CodePushCordovaPlugin {
      * Calling this function is required on the first run after an update. On every subsequent application run, calling this function is a noop.
      * If using sync API, calling this function is not required since sync calls it internally.
      *
-     * @param deploymentKey Optional string deployment key for this package.
      * @param notifySucceeded Optional callback invoked if the plugin was successfully notified.
      * @param notifyFailed Optional callback invoked in case of an error during notifying the plugin.
+     * @param deploymentKey Optional deployment key that overrides the config.xml setting.
      */
-    public notifyApplicationReady(deploymentKey?: string, notifySucceeded?: SuccessCallback<void>, notifyFailed?: ErrorCallback): void {
+    public notifyApplicationReady(notifySucceeded?: SuccessCallback<void>, notifyFailed?: ErrorCallback, deploymentKey?: string): void {
         cordova.exec(notifySucceeded, notifyFailed, "CodePush", "updateSuccess", [deploymentKey]);
     }
 
@@ -294,7 +294,7 @@ class CodePush implements CodePushCordovaPlugin {
             CodePushUtil.copyUnassignedMembers(defaultOptions, syncOptions);
         }
 
-        window.codePush.notifyApplicationReady(syncOptions.deploymentKey);
+        window.codePush.notifyApplicationReady(null, null, syncOptions.deploymentKey);
 
         var onError = (error: Error) => {
             CodePushUtil.logError("An error occurred during sync.", error);


### PR DESCRIPTION
Fixes a crash that was caused by attempting to report status when the deployment key wasn't specified in config.xml.

Addresses https://github.com/Microsoft/cordova-plugin-code-push/issues/108

@lostintangent @geof90 