### PR TITLE
Work around crash with no deployment key in config.xml

### DIFF
--- a/src/android/CodePushReportingManager.java
+++ b/src/android/CodePushReportingManager.java
@@ -46,6 +46,10 @@ public class CodePushReportingManager {
      */
     public void reportStatus(Status status, String label, String appVersion, String deploymentKey, final CordovaWebView webView) {
         /* JS function to call: window.codePush.reportStatus(status: number, label: String, appVersion: String, currentDeploymentKey: String, previousLabelOrAppVersion?: string, previousDeploymentKey?: string) */
+        if (deploymentKey == null || deploymentKey.isEmpty()) {
+            return;
+        }
+
         final String script = String.format(
             Locale.US,
             "javascript:document.addEventListener(\"deviceready\", function () { window.codePush.reportStatus(%d, %s, %s, %s, %s, %s); });",

--- a/src/ios/CodePushReportingManager.m
+++ b/src/ios/CodePushReportingManager.m
@@ -8,6 +8,10 @@ const NSString* LastVersionLabelOrAppVersionKey = @"LAST_VERSION_LABEL_OR_APP_VE
 
 + (void)reportStatus:(ReportingStatus)status withLabel:(NSString*)label version:(NSString*)version deploymentKey:(NSString*)deploymentKey webView:(UIView*)webView {
     @synchronized(self) {
+        if (!deploymentKey) {
+            return;
+        }
+
         NSString* labelParameter = [CodePushReportingManager convertStringParameter:label];
         NSString* appVersionParameter = [CodePushReportingManager convertStringParameter:version];
         NSString* deploymentKeyParameter = [CodePushReportingManager convertStringParameter:deploymentKey];


### PR DESCRIPTION
The crash itself was coming from attempting to save away some information in an NSDictionary with a nil value.

After some discussion, we decided that at this time, it would be best to no-op the reporting in the case where config.xml deployment key is not set, as this is consistent with the behaviour of the react native plugin, and it unblocks this scenario.

@lostintangent @dlebu @geof90 