### PR TITLE
Format the license in package.json to match the SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cordova-plugin-device": ">=1.1.0"
   },
   "author": "Microsoft Corporation",
-  "license": "Licensed under the MIT license.",
+  "license": "MIT",
   "devDependencies": {
     "gulp": "latest",
     "gulp-typescript": "latest",


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package. This commit changes the license to a valid SPDX value (MIT)