### PR TITLE
fix WkWebView tests

### DIFF
--- a/test/test.ts
+++ b/test/test.ts
@@ -169,7 +169,7 @@ function runTests(targetPlatform: platform.IPlatform, useWkWebView: boolean): vo
         app.use(function(req: any, res: any, next: any) {
             res.setHeader("Access-Control-Allow-Origin", "*");
             res.setHeader("Access-Control-Allow-Methods", "*");
-            res.setHeader("Access-Control-Allow-Headers", "origin, content-type, accept");
+            res.setHeader("Access-Control-Allow-Headers", "origin, content-type, accept, X-CodePush-SDK-Version");
             next();
         });
 


### PR DESCRIPTION
for some reason, the wkwebview tests are sending requests with X-CodePush-SDK-Version headers while the uiwebview tests do not, which the server was not configured to handle