### PR TITLE
fix small bugs in testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,6 @@
     "cordova-android",
     "cordova-ios"
   ],
-  "peerDependencies": {
-    "code-push": ">=1.8.0-beta",
-    "cordova-plugin-file-transfer": ">=1.3.0",
-    "cordova-plugin-zip": ">=3.0.0",
-    "cordova-plugin-dialogs": ">=1.1.1",
-    "cordova-plugin-device": ">=1.1.0"
-  },
   "author": "Microsoft Corporation",
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "peerDependencies": {
     "code-push": ">=1.8.0-beta",
     "cordova-plugin-file-transfer": ">=1.3.0",
-    "cordova-plugin-file": ">=3.0.0",
     "cordova-plugin-zip": ">=3.0.0",
     "cordova-plugin-dialogs": ">=1.1.1",
     "cordova-plugin-device": ">=1.1.0"

--- a/test/template/www/js/scenarioRestart.js
+++ b/test/template/www/js/scenarioRestart.js
@@ -36,7 +36,8 @@ var app = {
         window.codePush.restartApplication(
             function () {
                 /* success */
-                app.sendTestMessage("RESTART_SUCCEEDED");
+                // does not always send...rely on RESTART_FAILED to provide failure state instead of checking for RESTART_SUCCEEDED
+                // app.sendTestMessage("RESTART_SUCCEEDED");
                 callback && callback();
             },
             function () {

--- a/test/template/www/js/scenarioRestart.js
+++ b/test/template/www/js/scenarioRestart.js
@@ -35,9 +35,6 @@ var app = {
     tryRestart: function (callback) {
         window.codePush.restartApplication(
             function () {
-                /* success */
-                // does not always send...rely on RESTART_FAILED to provide failure state instead of checking for RESTART_SUCCEEDED
-                // app.sendTestMessage("RESTART_SUCCEEDED");
                 callback && callback();
             },
             function () {

--- a/test/test.ts
+++ b/test/test.ts
@@ -893,7 +893,7 @@ function runTests(targetPlatform: platform.IPlatform, useWkWebView: boolean): vo
                             new su.AppMessage(su.TestMessage.SYNC_STATUS, [su.TestMessage.SYNC_UPDATE_INSTALLED]),
                             new su.AppMessage(su.TestMessage.PENDING_PACKAGE, [mockResponse.updateInfo.packageHash]),
                             new su.AppMessage(su.TestMessage.CURRENT_PACKAGE, [null]),
-                            su.TestMessage.RESTART_SUCCEEDED,
+                            // su.TestMessage.RESTART_SUCCEEDED,
                             su.TestMessage.DEVICE_READY_AFTER_UPDATE,
                             su.TestMessage.NOTIFY_APP_READY_SUCCESS
                         ], deferred);

--- a/test/test.ts
+++ b/test/test.ts
@@ -893,7 +893,6 @@ function runTests(targetPlatform: platform.IPlatform, useWkWebView: boolean): vo
                             new su.AppMessage(su.TestMessage.SYNC_STATUS, [su.TestMessage.SYNC_UPDATE_INSTALLED]),
                             new su.AppMessage(su.TestMessage.PENDING_PACKAGE, [mockResponse.updateInfo.packageHash]),
                             new su.AppMessage(su.TestMessage.CURRENT_PACKAGE, [null]),
-                            // su.TestMessage.RESTART_SUCCEEDED,
                             su.TestMessage.DEVICE_READY_AFTER_UPDATE,
                             su.TestMessage.NOTIFY_APP_READY_SUCCESS
                         ], deferred);


### PR DESCRIPTION
file transfer includes file@^3.0.0 as a dependency, but we install file@>=3.0.0. As a result, file transfer is incompatible with the version of file that we install and makes npm install exit with nonzero, even though it still installs everything and you can run everything fine. This fix keeps our dependency on file while allowing us to not have to update it to keep it consistent with the version that file-transfer depends on

Additionally, I removed the RESTART_SUCCEEDED message from the restartApplication test case. It was not being reliably sent on wkwebview (likely due to the webview being killed before it sends completely since it performs faster than uiwebview), and since when the restart step fails it will still call RESTART_FAILED and fail the test it's not necessary.

with this merged, the automated tests finally completely succeed!
https://mobiledevops.visualstudio.com/VS%20Client/_build?_a=summary&buildId=3908
https://mobiledevops.visualstudio.com/_permalink/_build/index?collectionId=ffea02da-5599-45aa-a688-8709d085b2fb&projectId=5fc0653c-f92f-4d49-9e5e-a6aa08350131&buildId=3909