### PR TITLE
Retry reportStatus if failure

### DIFF
--- a/bin/www/codePush.js
+++ b/bin/www/codePush.js
@@ -24,30 +24,43 @@ var CodePush = (function () {
     CodePush.prototype.restartApplication = function (installSuccess, errorCallback) {
         cordova.exec(installSuccess, errorCallback, "CodePush", "restartApplication", []);
     };
-    CodePush.prototype.reportStatus = function (status, label, appVersion, currentDeploymentKey, previousLabelOrAppVersion, previousDeploymentKey) {
-        try {
-            var createPackageForReporting = function (label, appVersion) {
-                return {
-                    label: label, appVersion: appVersion,
-                    deploymentKey: currentDeploymentKey, description: null,
-                    isMandatory: false, packageHash: null,
-                    packageSize: null, failedInstall: false
-                };
+    CodePush.prototype.reportStatus = function (status, label, appVersion, deploymentKey, previousLabelOrAppVersion, previousDeploymentKey) {
+        var createPackageForReporting = function (label, appVersion) {
+            return {
+                label: label, appVersion: appVersion, deploymentKey: deploymentKey,
+                description: null, isMandatory: false,
+                packageHash: null, packageSize: null,
+                failedInstall: false
             };
-            switch (status) {
-                case ReportStatus.STORE_VERSION:
-                    Sdk.reportStatusDeploy(null, AcquisitionStatus.DeploymentSucceeded, currentDeploymentKey, previousLabelOrAppVersion, previousDeploymentKey);
-                    break;
-                case ReportStatus.UPDATE_CONFIRMED:
-                    Sdk.reportStatusDeploy(createPackageForReporting(label, appVersion), AcquisitionStatus.DeploymentSucceeded, currentDeploymentKey, previousLabelOrAppVersion, previousDeploymentKey);
-                    break;
-                case ReportStatus.UPDATE_ROLLED_BACK:
-                    Sdk.reportStatusDeploy(createPackageForReporting(label, appVersion), AcquisitionStatus.DeploymentFailed, currentDeploymentKey, previousLabelOrAppVersion, previousDeploymentKey);
-                    break;
+        };
+        var reportDone = function (error) {
+            var reportArgs = {
+                status: status,
+                label: label,
+                appVersion: appVersion,
+                deploymentKey: deploymentKey,
+                previousLabelOrAppVersion: previousLabelOrAppVersion,
+                previousDeploymentKey: previousDeploymentKey
+            };
+            if (error) {
+                CodePushUtil.logError("An error occurred while reporting status: " + JSON.stringify(reportArgs), error);
+                cordova.exec(null, null, "CodePush", "reportFailed", [reportArgs]);
             }
-        }
-        catch (e) {
-            CodePushUtil.logError("An error occurred while reporting." + CodePushUtil.getErrorMessage(e));
+            else {
+                CodePushUtil.logMessage("Reported status: " + JSON.stringify(reportArgs));
+                cordova.exec(null, null, "CodePush", "reportSucceeded", [reportArgs]);
+            }
+        };
+        switch (status) {
+            case ReportStatus.STORE_VERSION:
+                Sdk.reportStatusDeploy(null, AcquisitionStatus.DeploymentSucceeded, deploymentKey, previousLabelOrAppVersion, previousDeploymentKey, reportDone);
+                break;
+            case ReportStatus.UPDATE_CONFIRMED:
+                Sdk.reportStatusDeploy(createPackageForReporting(label, appVersion), AcquisitionStatus.DeploymentSucceeded, deploymentKey, previousLabelOrAppVersion, previousDeploymentKey, reportDone);
+                break;
+            case ReportStatus.UPDATE_ROLLED_BACK:
+                Sdk.reportStatusDeploy(createPackageForReporting(label, appVersion), AcquisitionStatus.DeploymentFailed, deploymentKey, previousLabelOrAppVersion, previousDeploymentKey, reportDone);
+                break;
         }
     };
     CodePush.prototype.getCurrentPackage = function (packageSuccess, packageError) {

--- a/bin/www/codePush.js
+++ b/bin/www/codePush.js
@@ -19,7 +19,7 @@ var CodePush = (function () {
     function CodePush() {
     }
     CodePush.prototype.notifyApplicationReady = function (notifySucceeded, notifyFailed) {
-        cordova.exec(notifySucceeded, notifyFailed, "CodePush", "updateSuccess", []);
+        cordova.exec(notifySucceeded, notifyFailed, "CodePush", "notifyApplicationReady", []);
     };
     CodePush.prototype.restartApplication = function (installSuccess, errorCallback) {
         cordova.exec(installSuccess, errorCallback, "CodePush", "restartApplication", []);

--- a/bin/www/sdk.js
+++ b/bin/www/sdk.js
@@ -70,13 +70,12 @@ var Sdk = (function () {
                     callback && callback(error, null);
                 }
                 else {
-                    console.log("Reporting status: " + status + " label: " + (pkg && pkg.label) + " appVersion: " + Sdk.DefaultConfiguration.appVersion + " previousLabelOrAppVersion: " + previousLabelOrAppVersion + " previousDeploymentKey:" + previousDeploymentKey);
                     acquisitionManager.reportStatusDeploy(pkg, status, previousLabelOrAppVersion, previousDeploymentKey, callback);
                 }
             }, currentDeploymentKey, "application/json");
         }
         catch (e) {
-            callback && callback(new Error("An error occured while reporting the deployment status. " + e), null);
+            callback && callback(e, null);
         }
     };
     Sdk.reportStatusDownload = function (pkg, deploymentKey, callback) {

--- a/plugin.xml
+++ b/plugin.xml
@@ -7,8 +7,8 @@
         <repo>https://github.com/Microsoft/cordova-plugin-code-push.git</repo>
 
         <dependency id="code-push" version=">=1.8.0-beta" />
-        <dependency id="cordova-plugin-file" version=">=3.0.0" /> 
-        <dependency id="cordova-plugin-file-transfer" version=">=1.3.0" /> 
+        <dependency id="cordova-plugin-file" version=">=3.0.0" />
+        <dependency id="cordova-plugin-file-transfer" version=">=1.3.0" />
         <dependency id="cordova-plugin-zip" version=">=3.0.0" />
         <dependency id="cordova-plugin-dialogs" version=">=1.1.1" />
         <dependency id="cordova-plugin-device" version=">=1.1.0" />
@@ -66,8 +66,10 @@
             <source-file src="src/android/CodePushReportingManager.java" target-dir="src/com/microsoft/cordova" />
             <source-file src="src/android/InstallMode.java" target-dir="src/com/microsoft/cordova" />
             <source-file src="src/android/InstallOptions.java" target-dir="src/com/microsoft/cordova" />
-            <source-file src="src/android/Utilities.java" target-dir="src/com/microsoft/cordova" />
+            <source-file src="src/android/ReportingStatus.java" target-dir="src/com/microsoft/cordova" />
+            <source-file src="src/android/StatusReport.java" target-dir="src/com/microsoft/cordova" />
             <source-file src="src/android/UpdateHashUtils.java" target-dir="src/com/microsoft/cordova" />
+            <source-file src="src/android/Utilities.java" target-dir="src/com/microsoft/cordova" />
             <config-file target="config.xml" parent="/*">
                 <feature name="CodePush">
                     <param name="android-package" value="com.microsoft.cordova.CodePush" />
@@ -83,15 +85,17 @@
             <source-file src="src/ios/CodePushPackageMetadata.m" />
             <header-file src="src/ios/CodePushPackageManager.h" />
             <source-file src="src/ios/CodePushPackageManager.m" />
-            <source-file src="src/ios/CodePushReportingManager.m" />
             <header-file src="src/ios/CodePushReportingManager.h" />
-            <header-file src="src/ios/Utilities.h" />
-            <source-file src="src/ios/Utilities.m" />
+            <source-file src="src/ios/CodePushReportingManager.m" />
             <header-file src="src/ios/InstallOptions.h" />
             <source-file src="src/ios/InstallOptions.m" />
             <header-file src="src/ios/InstallMode.h" />
-            <source-file src="src/ios/UpdateHashUtils.m" />
+            <header-file src="src/ios/StatusReport.h" />
+            <source-file src="src/ios/StatusReport.m" />
             <header-file src="src/ios/UpdateHashUtils.h" />
+            <source-file src="src/ios/UpdateHashUtils.m" />
+            <header-file src="src/ios/Utilities.h" />
+            <source-file src="src/ios/Utilities.m" />
             <config-file target="config.xml" parent="/*">
                 <feature name="CodePush">
                     <param name="ios-package" value="CodePush" />

--- a/src/android/CodePushPreferences.java
+++ b/src/android/CodePushPreferences.java
@@ -3,6 +3,8 @@ package com.microsoft.cordova;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import org.json.JSONException;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -20,6 +22,8 @@ public class CodePushPreferences {
     private static final String INSTALL_MIN_BACKGROUND_DURATION = "INSTALL_MINIMUM_BACKGROUND_DURATION";
     private static final String INSTALL_NEEDS_CONFIRMATION = "INSTALL_NEEDS_CONFIRMATION";
     private static final String INSTALL_NEEDS_CONFIRMATION_KEY = "INSTALL_NEEDS_CONFIRMATION_KEY";
+    private static final String FAILED_STATUS_REPORT_PREFERENCE = "CODE_PUSH_FAILED_STATUS_REPORT_PREFERENCE";
+    private static final String FAILED_STATUS_REPORT_PREFERENCE_KEY = "CODE_PUSH_FAILED_STATUS_REPORT_PREFERENCE_KEY";
     private static final String FIRST_RUN_PREFERENCE = "CODE_PUSH_FIRST_RUN";
     private static final String FIRST_RUN_PREFERENCE_KEY = "CODE_PUSH_FIRST_RUN_KEY";
     private static final String LAST_VERSION_PREFERENCE = "CODE_PUSH_LAST_VERSION";
@@ -131,6 +135,29 @@ public class CodePushPreferences {
         SharedPreferences preferences = context.getSharedPreferences(preferencesId, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = preferences.edit();
         editor.clear();
+        editor.commit();
+    }
+
+    public void clearFailedReport() {
+        this.clearPreferences(CodePushPreferences.FAILED_STATUS_REPORT_PREFERENCE);
+    }
+
+    public StatusReport getFailedReport() {
+        SharedPreferences preferences = context.getSharedPreferences(CodePushPreferences.FAILED_STATUS_REPORT_PREFERENCE, Context.MODE_PRIVATE);
+        String statusReportJson = preferences.getString(CodePushPreferences.FAILED_STATUS_REPORT_PREFERENCE_KEY, null);
+        try {
+            return statusReportJson == null ? null : StatusReport.deserialize(statusReportJson);
+        } catch (JSONException e) {
+            // Should not happen
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    public void saveFailedReport(StatusReport statusReport) {
+        SharedPreferences preferences = context.getSharedPreferences(CodePushPreferences.FAILED_STATUS_REPORT_PREFERENCE, Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = preferences.edit();
+        editor.putString(CodePushPreferences.FAILED_STATUS_REPORT_PREFERENCE_KEY, statusReport.serialize());
         editor.commit();
     }
 

--- a/src/android/CodePushReportingManager.java
+++ b/src/android/CodePushReportingManager.java
@@ -47,11 +47,11 @@ public class CodePushReportingManager {
     }
 
     public boolean hasFailedReport() {
-        if (this.hasFailedReport == null) {
-            this.hasFailedReport = codePushPreferences.getFailedReport() != null;
+        if (hasFailedReport == null) {
+            hasFailedReport = codePushPreferences.getFailedReport() != null;
         }
 
-        return this.hasFailedReport;
+        return hasFailedReport;
     }
 
     public StatusReport getAndClearFailedReport() {

--- a/src/android/CodePushReportingManager.java
+++ b/src/android/CodePushReportingManager.java
@@ -2,7 +2,6 @@ package com.microsoft.cordova;
 
 import org.apache.cordova.CordovaWebView;
 
-import java.util.ArrayList;
 import java.util.Locale;
 import android.app.Activity;
 
@@ -13,28 +12,7 @@ public class CodePushReportingManager {
 
     private Activity cordovaActivity;
     private CodePushPreferences codePushPreferences;
-
-    /**
-     * Defines application statuses we use in reporting events from the native to the JS layer.
-     */
-    public static enum Status {
-        STORE_VERSION(0),
-        UPDATE_CONFIRMED(1),
-        UPDATE_ROLLED_BACK(2);
-
-        private int value;
-
-        Status(int i) {
-            this.value = i;
-        }
-
-        /**
-         * Returns the value associated with this enum.
-         */
-        public int getValue() {
-            return this.value;
-        }
-    }
+    private Boolean hasFailedReport = null;
 
     public CodePushReportingManager(Activity cordovaActivity, CodePushPreferences codePushPreferences) {
         this.cordovaActivity = cordovaActivity;
@@ -44,32 +22,56 @@ public class CodePushReportingManager {
     /**
      * Invokes the window.codePush.reportStatus JS function for the given webView.
      */
-    public void reportStatus(Status status, String label, String appVersion, String deploymentKey, final CordovaWebView webView) {
+    public void reportStatus(StatusReport statusReport, final CordovaWebView webView) {
         /* JS function to call: window.codePush.reportStatus(status: number, label: String, appVersion: String, currentDeploymentKey: String, previousLabelOrAppVersion?: string, previousDeploymentKey?: string) */
-        if (deploymentKey == null || deploymentKey.isEmpty()) {
+        if (statusReport.deploymentKey == null || statusReport.deploymentKey.isEmpty()) {
             return;
         }
 
         final String script = String.format(
             Locale.US,
             "javascript:document.addEventListener(\"deviceready\", function () { window.codePush.reportStatus(%d, %s, %s, %s, %s, %s); });",
-            status.getValue(),
-            convertStringParameter(label),
-            convertStringParameter(appVersion),
-            convertStringParameter(deploymentKey),
-            convertStringParameter(codePushPreferences.getLastVersionLabelOrAppVersion()),
-            convertStringParameter(codePushPreferences.getLastVersionDeploymentKey())
-            );
-
-        if (status == Status.STORE_VERSION || status == Status.UPDATE_CONFIRMED) {
-            codePushPreferences.saveLastVersion(label == null ? appVersion : label, deploymentKey);
-        }
+            statusReport.status.getValue(),
+            convertStringParameter(statusReport.label),
+            convertStringParameter(statusReport.appVersion),
+            convertStringParameter(statusReport.deploymentKey),
+            statusReport.lastVersionLabelOrAppVersion == null ? convertStringParameter(codePushPreferences.getLastVersionLabelOrAppVersion()) : convertStringParameter(statusReport.lastVersionLabelOrAppVersion),
+            statusReport.lastVersionDeploymentKey == null ? convertStringParameter(codePushPreferences.getLastVersionDeploymentKey()) : convertStringParameter(statusReport.lastVersionDeploymentKey)
+        );
 
         cordovaActivity.runOnUiThread(new Runnable() {
             public void run() {
                 webView.loadUrl(script);
             }
         });
+    }
+
+    public boolean hasFailedReport() {
+        if (this.hasFailedReport == null) {
+            this.hasFailedReport = codePushPreferences.getFailedReport() != null;
+        }
+
+        return this.hasFailedReport;
+    }
+
+    public StatusReport getAndClearFailedReport() {
+        StatusReport failedReport = codePushPreferences.getFailedReport();
+        codePushPreferences.clearFailedReport();
+        this.hasFailedReport = false;
+        return failedReport;
+    }
+
+    public void saveFailedReport(StatusReport statusReport) {
+        codePushPreferences.saveFailedReport(statusReport);
+        this.hasFailedReport = true;
+    }
+
+    public void saveSuccessfulReport(StatusReport statusReport) {
+        if (statusReport.status == ReportingStatus.STORE_VERSION || statusReport.status == ReportingStatus.UPDATE_CONFIRMED) {
+            codePushPreferences.saveLastVersion(statusReport.label == null ? statusReport.appVersion : statusReport.label, statusReport.deploymentKey);
+            codePushPreferences.clearFailedReport();
+            this.hasFailedReport = false;
+        }
     }
 
     private String convertStringParameter(String input) {

--- a/src/android/ReportingStatus.java
+++ b/src/android/ReportingStatus.java
@@ -1,0 +1,23 @@
+package com.microsoft.cordova;
+
+/**
+ * Defines application statuses we use in reporting events from the native to the JS layer.
+ */
+public enum ReportingStatus {
+    STORE_VERSION(0),
+    UPDATE_CONFIRMED(1),
+    UPDATE_ROLLED_BACK(2);
+
+    private int value;
+
+    ReportingStatus(int i) {
+        this.value = i;
+    }
+
+    /**
+     * Returns the value associated with this enum.
+     */
+    public int getValue() {
+        return this.value;
+    }
+}

--- a/src/android/StatusReport.java
+++ b/src/android/StatusReport.java
@@ -3,6 +3,9 @@ package com.microsoft.cordova;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+/**
+ * Represents a status report to be sent to metrics.
+ */
 public class StatusReport {
 
     private static final String STATUS_KEY = "status";
@@ -16,6 +19,8 @@ public class StatusReport {
     String label;
     String appVersion;
     String deploymentKey;
+
+    // Optional fields.
     String lastVersionLabelOrAppVersion;
     String lastVersionDeploymentKey;
 

--- a/src/android/StatusReport.java
+++ b/src/android/StatusReport.java
@@ -1,0 +1,80 @@
+package com.microsoft.cordova;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class StatusReport {
+
+    private static final String STATUS_KEY = "status";
+    private static final String LABEL_KEY = "label";
+    private static final String APP_VERSION_KEY = "appVersion";
+    private static final String DEPLOYMENT_KEY_KEY = "deploymentKey";
+    private static final String LAST_VERSION_LABEL_OR_APP_VERSION_KEY = "lastVersionLabelOrAppVersion";
+    private static final String LAST_VERSION_DEPLOYMENT_KEY_KEY = "lastVersionDeploymentKey";
+
+    ReportingStatus status;
+    String label;
+    String appVersion;
+    String deploymentKey;
+    String lastVersionLabelOrAppVersion;
+    String lastVersionDeploymentKey;
+
+    public StatusReport(int status, String label, String appVersion, String deploymentKey, String lastVersionLabelOrAppVersion, String lastVersionDeploymentKey) {
+        this(ReportingStatus.values()[status], label, appVersion, deploymentKey, lastVersionLabelOrAppVersion, lastVersionDeploymentKey);
+    }
+
+    public StatusReport(ReportingStatus status, String label, String appVersion, String deploymentKey) {
+        this(status, label, appVersion, deploymentKey, null, null);
+    }
+
+    public StatusReport(ReportingStatus status, String label, String appVersion, String deploymentKey, String lastVersionLabelOrAppVersion, String lastVersionDeploymentKey) {
+        this.status = status;
+        this.label = label;
+        this.appVersion = appVersion;
+        this.deploymentKey = deploymentKey;
+        this.lastVersionLabelOrAppVersion = lastVersionLabelOrAppVersion;
+        this.lastVersionDeploymentKey = lastVersionDeploymentKey;
+    }
+
+    public String serialize() {
+        try {
+            JSONObject jsonObject = new JSONObject();
+            jsonObject.put(STATUS_KEY, status.getValue());
+            jsonObject.put(LABEL_KEY, label);
+            jsonObject.put(APP_VERSION_KEY, appVersion);
+            if (deploymentKey != null) {
+                jsonObject.put(DEPLOYMENT_KEY_KEY, deploymentKey);
+            }
+
+            if (lastVersionLabelOrAppVersion != null) {
+                jsonObject.put(LAST_VERSION_LABEL_OR_APP_VERSION_KEY, lastVersionLabelOrAppVersion);
+            }
+
+            if (lastVersionDeploymentKey != null) {
+                jsonObject.put(LAST_VERSION_DEPLOYMENT_KEY_KEY, lastVersionDeploymentKey);
+            }
+
+            return jsonObject.toString();
+        } catch (JSONException e) {
+            // Should not happen
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    public static StatusReport deserialize(JSONObject jsonObject) throws JSONException {
+        return new StatusReport(
+                jsonObject.optInt(STATUS_KEY),
+                jsonObject.optString(LABEL_KEY, null),
+                jsonObject.optString(APP_VERSION_KEY, null),
+                jsonObject.optString(DEPLOYMENT_KEY_KEY, null),
+                jsonObject.optString(LAST_VERSION_LABEL_OR_APP_VERSION_KEY, null),
+                jsonObject.optString(LAST_VERSION_DEPLOYMENT_KEY_KEY, null)
+        );
+    }
+
+    public static StatusReport deserialize(String jsonString) throws JSONException {
+        JSONObject jsonObject = new JSONObject(jsonString);
+        return deserialize(jsonObject);
+    }
+}

--- a/src/ios/CodePushReportingManager.h
+++ b/src/ios/CodePushReportingManager.h
@@ -1,11 +1,12 @@
-enum {
-    STORE_VERSION = 0,
-    UPDATE_CONFIRMED = 1,
-    UPDATE_ROLLED_BACK = 2
-};
-typedef NSInteger ReportingStatus;
+#import "StatusReport.h"
 
 @interface CodePushReportingManager : NSObject
-+ (void)reportStatus:(ReportingStatus)status withLabel:(NSString*)label version:(NSString*)version deploymentKey:(NSString*)deploymentKey webView:(UIView*)webView;
-@end
 
++ (void)reportStatus:(StatusReport*)statusReport withWebView:(UIView*)webView;
++ (BOOL)hasFailedReport;
++ (StatusReport*)getFailedReport;
++ (StatusReport*)getAndClearFailedReport;
++ (void)saveFailedReport:(StatusReport*)statusReport;
++ (void)saveSuccessfulReport:(StatusReport*)statusReport;
+
+@end

--- a/src/ios/CodePushReportingManager.m
+++ b/src/ios/CodePushReportingManager.m
@@ -21,7 +21,7 @@ NSString* const LastVersionPreferenceLabelOrAppVersionKey = @"LAST_VERSION_LABEL
         NSString* deploymentKeyParameter = [CodePushReportingManager convertStringParameter:statusReport.deploymentKey];
         NSString* lastVersionLabelOrAppVersionParameter = statusReport.lastVersionLabelOrAppVersion;
         NSString* lastVersionDeploymentKeyParameter = statusReport.lastVersionDeploymentKey;
-        if (!lastVersionLabelOrAppVersionParameter || !lastVersionDeploymentKeyParameter) {
+        if (!lastVersionLabelOrAppVersionParameter && !lastVersionDeploymentKeyParameter) {
             NSUserDefaults* preferences = [NSUserDefaults standardUserDefaults];
             NSDictionary* lastVersion = [preferences objectForKey:LastVersionPreference];
             if (lastVersion) {

--- a/src/ios/InstallOptions.h
+++ b/src/ios/InstallOptions.h
@@ -1,4 +1,4 @@
-#include "InstallMode.h"
+#import "InstallMode.h"
 
 @interface InstallOptions : NSObject
 

--- a/src/ios/InstallOptions.m
+++ b/src/ios/InstallOptions.m
@@ -1,4 +1,4 @@
-#include "InstallOptions.h"
+#import "InstallOptions.h"
 
 @implementation InstallOptions
 

--- a/src/ios/StatusReport.h
+++ b/src/ios/StatusReport.h
@@ -11,6 +11,8 @@ typedef NSInteger ReportingStatus;
 @property NSString* label;
 @property NSString* appVersion;
 @property NSString* deploymentKey;
+
+// Optional properties.
 @property NSString* lastVersionLabelOrAppVersion;
 @property NSString* lastVersionDeploymentKey;
 

--- a/src/ios/StatusReport.h
+++ b/src/ios/StatusReport.h
@@ -1,0 +1,25 @@
+enum {
+    STORE_VERSION = 0,
+    UPDATE_CONFIRMED = 1,
+    UPDATE_ROLLED_BACK = 2
+};
+typedef NSInteger ReportingStatus;
+
+@interface StatusReport : NSObject
+
+@property ReportingStatus status;
+@property NSString* label;
+@property NSString* appVersion;
+@property NSString* deploymentKey;
+@property NSString* lastVersionLabelOrAppVersion;
+@property NSString* lastVersionDeploymentKey;
+
+- (id)initWithStatus:(ReportingStatus)status andLabel:(NSString*)label andAppVersion:(NSString*)appVersion andDeploymentKey:(NSString*)deploymentKey;
+
+- (id)initWithStatus:(ReportingStatus)status andLabel:(NSString*)label andAppVersion:(NSString*)appVersion andDeploymentKey:(NSString*)deploymentKey andLastVersionLabelOrAppVersion:(NSString*)lastVersionLabelOrAppVersion andLastVersionDeploymentKey:(NSString*)lastVersionDeploymentKey;
+
+- (id)initWithDictionary:(NSDictionary*)dict;
+
+- (NSDictionary*)toDictionary;
+
+@end

--- a/src/ios/StatusReport.m
+++ b/src/ios/StatusReport.m
@@ -1,0 +1,46 @@
+#import "StatusReport.h"
+
+@implementation StatusReport
+
+const NSString* StatusKey = @"status";
+const NSString* LabelKey = @"label";
+const NSString* AppVersionKey = @"appVersion";
+const NSString* DeploymentKeyKey = @"deploymentKey";
+const NSString* LastVersionLabelOrAppVersionKey = @"lastVersionLabelOrAppVersion";
+const NSString* LastVersionDeploymentKeyKey = @"lastVersionDeploymentKey";
+
+- (id)initWithStatus:(ReportingStatus)status andLabel:(NSString*)label andAppVersion:(NSString*)appVersion andDeploymentKey:(NSString*)deploymentKey {
+    return [self initWithStatus:status andLabel:label andAppVersion:appVersion andDeploymentKey:deploymentKey andLastVersionLabelOrAppVersion:nil andLastVersionDeploymentKey:nil];
+}
+
+
+- (id)initWithStatus:(ReportingStatus)status andLabel:(NSString*)label andAppVersion:(NSString*)appVersion andDeploymentKey:(NSString*)deploymentKey andLastVersionLabelOrAppVersion:(NSString*)lastVersionLabelOrAppVersion andLastVersionDeploymentKey:(NSString*)lastVersionDeploymentKey {
+    self = [super init];
+    if (self) {
+        _status = status;
+        _label = label;
+        _appVersion = appVersion;
+        _deploymentKey = deploymentKey;
+        _lastVersionLabelOrAppVersion = lastVersionLabelOrAppVersion;
+        _lastVersionDeploymentKey = lastVersionDeploymentKey;
+    }
+    
+    return self;
+}
+
+- (id)initWithDictionary:(NSDictionary*)dict {
+    return [self initWithStatus:[dict[StatusKey] longValue] andLabel:dict[LabelKey] andAppVersion:dict[AppVersionKey] andDeploymentKey:dict[DeploymentKeyKey] andLastVersionLabelOrAppVersion:dict[LastVersionLabelOrAppVersionKey] andLastVersionDeploymentKey:dict[LastVersionDeploymentKeyKey]];
+}
+
+- (NSDictionary*)toDictionary {
+    NSMutableDictionary* dict = [[NSMutableDictionary alloc] init];
+    dict[StatusKey] = @(_status);
+    if (_label) dict[LabelKey] = _label;
+    if (_appVersion) dict[AppVersionKey] = _appVersion;
+    if (_deploymentKey) dict[DeploymentKeyKey] = _deploymentKey;
+    if (_lastVersionLabelOrAppVersion) dict[LastVersionLabelOrAppVersionKey] = _lastVersionLabelOrAppVersion;
+    if (_lastVersionDeploymentKey) dict[LastVersionDeploymentKeyKey] = _lastVersionDeploymentKey;
+    return dict;
+}
+
+@end

--- a/typings/cordova.d.ts
+++ b/typings/cordova.d.ts
@@ -14,7 +14,7 @@ interface Cordova {
      * @param action The action name to call on the native side (generally corresponds to the native class method).
      * @param args An array of arguments to pass into the native environment.
      */
-    exec(success: () => any, fail: () => any, service: string, action: string, args?: string[]): void;
+    exec(success: () => any, fail: () => any, service: string, action: string, args?: any[]): void;
     /** Gets the operating system name. */
     platformId: string;
     /** Gets Cordova framework version */

--- a/www/codePush.ts
+++ b/www/codePush.ts
@@ -47,7 +47,7 @@ class CodePush implements CodePushCordovaPlugin {
      * @param notifyFailed Optional callback invoked in case of an error during notifying the plugin.
      */
     public notifyApplicationReady(notifySucceeded?: SuccessCallback<void>, notifyFailed?: ErrorCallback): void {
-        cordova.exec(notifySucceeded, notifyFailed, "CodePush", "updateSuccess", []);
+        cordova.exec(notifySucceeded, notifyFailed, "CodePush", "notifyApplicationReady", []);
     }
 
     /**

--- a/www/codePush.ts
+++ b/www/codePush.ts
@@ -62,32 +62,47 @@ class CodePush implements CodePushCordovaPlugin {
      * Reports an application status back to the server.
      * !!! This function is called from the native side, please make changes accordingly. !!!
      */
-    public reportStatus(status: number, label: string, appVersion: string, currentDeploymentKey: string, previousLabelOrAppVersion?: string, previousDeploymentKey?: string) {
-        try {
-            var createPackageForReporting = (label: string, appVersion: string): IPackage => {
-                return {
-                    /* The SDK only reports the label and appVersion.
-                       The rest of the properties are added for type safety. */
-                    label: label, appVersion: appVersion,
-                    deploymentKey: currentDeploymentKey, description: null,
-                    isMandatory: false, packageHash: null,
-                    packageSize: null, failedInstall: false
-                };
+    public reportStatus(status: number, label: string, appVersion: string, deploymentKey: string, previousLabelOrAppVersion?: string, previousDeploymentKey?: string) {
+       var createPackageForReporting = (label: string, appVersion: string): IPackage => {
+            return {
+                /* The SDK only reports the label and appVersion.
+                   The rest of the properties are added for type safety. */
+                label, appVersion, deploymentKey,
+                description: null, isMandatory: false,
+                packageHash: null, packageSize: null,
+                failedInstall: false
+            };
+        };
+
+        var reportDone = (error: Error) => {
+            var reportArgs = {
+                status,
+                label,
+                appVersion,
+                deploymentKey,
+                previousLabelOrAppVersion,
+                previousDeploymentKey
             };
 
-            switch (status) {
-                case ReportStatus.STORE_VERSION:
-                    Sdk.reportStatusDeploy(null, AcquisitionStatus.DeploymentSucceeded, currentDeploymentKey, previousLabelOrAppVersion, previousDeploymentKey);
-                    break;
-                case ReportStatus.UPDATE_CONFIRMED:
-                    Sdk.reportStatusDeploy(createPackageForReporting(label, appVersion), AcquisitionStatus.DeploymentSucceeded, currentDeploymentKey, previousLabelOrAppVersion, previousDeploymentKey);
-                    break;
-                case ReportStatus.UPDATE_ROLLED_BACK:
-                    Sdk.reportStatusDeploy(createPackageForReporting(label, appVersion), AcquisitionStatus.DeploymentFailed, currentDeploymentKey, previousLabelOrAppVersion, previousDeploymentKey);
-                    break;
+            if (error) {
+                CodePushUtil.logError(`An error occurred while reporting status: ${JSON.stringify(reportArgs)}`, error);
+                cordova.exec(null, null, "CodePush", "reportFailed", [reportArgs]);
+            } else {
+                CodePushUtil.logMessage(`Reported status: ${JSON.stringify(reportArgs)}`);
+                cordova.exec(null, null, "CodePush", "reportSucceeded", [reportArgs]);
             }
-        } catch (e) {
-            CodePushUtil.logError("An error occurred while reporting." + CodePushUtil.getErrorMessage(e));
+        };
+
+        switch (status) {
+            case ReportStatus.STORE_VERSION:
+                Sdk.reportStatusDeploy(null, AcquisitionStatus.DeploymentSucceeded, deploymentKey, previousLabelOrAppVersion, previousDeploymentKey, reportDone);
+                break;
+            case ReportStatus.UPDATE_CONFIRMED:
+                Sdk.reportStatusDeploy(createPackageForReporting(label, appVersion), AcquisitionStatus.DeploymentSucceeded, deploymentKey, previousLabelOrAppVersion, previousDeploymentKey, reportDone);
+                break;
+            case ReportStatus.UPDATE_ROLLED_BACK:
+                Sdk.reportStatusDeploy(createPackageForReporting(label, appVersion), AcquisitionStatus.DeploymentFailed, deploymentKey, previousLabelOrAppVersion, previousDeploymentKey, reportDone);
+                break;
         }
     }
 
@@ -420,7 +435,6 @@ class CodePush implements CodePushCordovaPlugin {
 
         return CodePush.DefaultUpdateDialogOptions;
     }
-
 }
 
 /**

--- a/www/sdk.ts
+++ b/www/sdk.ts
@@ -77,12 +77,11 @@ class Sdk {
                     callback && callback(error, null);
                 }
                 else {
-                    console.log(`Reporting status: ${status} label: ${pkg && pkg.label} appVersion: ${Sdk.DefaultConfiguration.appVersion} previousLabelOrAppVersion: ${previousLabelOrAppVersion} previousDeploymentKey:${previousDeploymentKey}`);
                     acquisitionManager.reportStatusDeploy(pkg, status, previousLabelOrAppVersion, previousDeploymentKey, callback);
                 }
             }, currentDeploymentKey, "application/json");
         } catch (e) {
-            callback && callback(new Error("An error occured while reporting the deployment status. " + e), null);
+            callback && callback(e, null);
         }
     }
 


### PR DESCRIPTION
This PR improves the reportStatus mechanism in order to make sure that metrics reporting calls are not lost due to bad network conditions, hence prevents metrics numbers from being "corrupted".

In a nutshell, if the call to the server fails/times out, we will save a copy of the statusReport in the Preferences, and retry again the next time the app resumes.