### PR TITLE
Fix #126

### DIFF
--- a/bin/www/codePush.js
+++ b/bin/www/codePush.js
@@ -25,6 +25,11 @@ var CodePush = (function () {
         cordova.exec(installSuccess, errorCallback, "CodePush", "restartApplication", []);
     };
     CodePush.prototype.reportStatus = function (status, label, appVersion, deploymentKey, previousLabelOrAppVersion, previousDeploymentKey) {
+        if ((!label || label === previousLabelOrAppVersion) &&
+            appVersion === previousLabelOrAppVersion &&
+            deploymentKey == previousDeploymentKey) {
+            return;
+        }
         var createPackageForReporting = function (label, appVersion) {
             return {
                 label: label, appVersion: appVersion, deploymentKey: deploymentKey,

--- a/bin/www/codePush.js
+++ b/bin/www/codePush.js
@@ -27,7 +27,7 @@ var CodePush = (function () {
     CodePush.prototype.reportStatus = function (status, label, appVersion, deploymentKey, previousLabelOrAppVersion, previousDeploymentKey) {
         if ((!label || label === previousLabelOrAppVersion) &&
             appVersion === previousLabelOrAppVersion &&
-            deploymentKey == previousDeploymentKey) {
+            deploymentKey === previousDeploymentKey) {
             return;
         }
         var createPackageForReporting = function (label, appVersion) {

--- a/bin/www/codePush.js
+++ b/bin/www/codePush.js
@@ -25,9 +25,8 @@ var CodePush = (function () {
         cordova.exec(installSuccess, errorCallback, "CodePush", "restartApplication", []);
     };
     CodePush.prototype.reportStatus = function (status, label, appVersion, deploymentKey, previousLabelOrAppVersion, previousDeploymentKey) {
-        if ((!label || label === previousLabelOrAppVersion) &&
-            appVersion === previousLabelOrAppVersion &&
-            deploymentKey === previousDeploymentKey) {
+        if (((!label && appVersion === previousLabelOrAppVersion) || label === previousLabelOrAppVersion)
+            && deploymentKey === previousDeploymentKey) {
             return;
         }
         var createPackageForReporting = function (label, appVersion) {

--- a/src/android/CodePush.java
+++ b/src/android/CodePush.java
@@ -278,7 +278,7 @@ public class CodePush extends CordovaPlugin {
             long nativeBuildTime = Utilities.getApkEntryBuildTime(RESOURCES_BUNDLE, this.cordova.getActivity());
             if (nativeBuildTime != -1) {
                 String currentAppTimeStamp = String.valueOf(nativeBuildTime);
-                if (deployedPackageTimeStamp != null && !deployedPackageTimeStamp.equals(currentAppTimeStamp)) {
+                if (!currentAppTimeStamp.equals(deployedPackageTimeStamp)) {
                     this.codePushPackageManager.cleanDeployments();
                     this.codePushPackageManager.clearFailedUpdates();
                     this.codePushPackageManager.clearPendingInstall();
@@ -298,7 +298,7 @@ public class CodePush extends CordovaPlugin {
                 try {
                     navigateToFile(startPage);
                 } catch (MalformedURLException e) {
-                /* empty - if there is an exception, the app will launch with the bundled content */
+                    /* empty - if there is an exception, the app will launch with the bundled content */
                 }
             }
         }

--- a/src/android/CodePush.java
+++ b/src/android/CodePush.java
@@ -278,14 +278,12 @@ public class CodePush extends CordovaPlugin {
             long nativeBuildTime = Utilities.getApkEntryBuildTime(RESOURCES_BUNDLE, this.cordova.getActivity());
             if (nativeBuildTime != -1) {
                 String currentAppTimeStamp = String.valueOf(nativeBuildTime);
-                if ((deployedPackageTimeStamp != null) && (currentAppTimeStamp != null)) {
-                    if (!deployedPackageTimeStamp.equals(currentAppTimeStamp)) {
-                        this.codePushPackageManager.cleanDeployments();
-                        this.codePushPackageManager.clearFailedUpdates();
-                        this.codePushPackageManager.clearPendingInstall();
-                        this.codePushPackageManager.clearInstallNeedsConfirmation();
-                        this.codePushPackageManager.clearBinaryFirstRunFlag();
-                    }
+                if (deployedPackageTimeStamp != null && !deployedPackageTimeStamp.equals(currentAppTimeStamp)) {
+                    this.codePushPackageManager.cleanDeployments();
+                    this.codePushPackageManager.clearFailedUpdates();
+                    this.codePushPackageManager.clearPendingInstall();
+                    this.codePushPackageManager.clearInstallNeedsConfirmation();
+                    this.codePushPackageManager.clearBinaryFirstRunFlag();
                 }
             }
         }
@@ -293,16 +291,14 @@ public class CodePush extends CordovaPlugin {
 
     private void navigateToLocalDeploymentIfExists() {
         CodePushPackageMetadata deployedPackageMetadata = this.codePushPackageManager.getCurrentPackageMetadata();
-        if (deployedPackageMetadata != null) {
-            if (deployedPackageMetadata.localPath != null) {
-                File startPage = this.getStartPageForPackage(deployedPackageMetadata.localPath);
-                if (startPage != null) {
-                    /* file exists */
-                    try {
-                        navigateToFile(startPage);
-                    } catch (MalformedURLException e) {
-                    /* empty - if there is an exception, the app will launch with the bundled content */
-                    }
+        if (deployedPackageMetadata != null && deployedPackageMetadata.localPath != null) {
+            File startPage = this.getStartPageForPackage(deployedPackageMetadata.localPath);
+            if (startPage != null) {
+                /* file exists */
+                try {
+                    navigateToFile(startPage);
+                } catch (MalformedURLException e) {
+                /* empty - if there is an exception, the app will launch with the bundled content */
                 }
             }
         }

--- a/src/android/CodePush.java
+++ b/src/android/CodePush.java
@@ -109,9 +109,9 @@ public class CodePush extends CordovaPlugin {
     }
 
     private boolean execNotifyApplicationReady(CallbackContext callbackContext) {
-        if (this.codePushPackageManager.isFirstRun()) {
+        if (this.codePushPackageManager.isBinaryFirstRun()) {
             // Report first run of a store version app
-            this.codePushPackageManager.saveFirstRunFlag();
+            this.codePushPackageManager.saveBinaryFirstRunFlag();
             try {
                 String appVersion = Utilities.getAppVersionName(cordova.getActivity());
                 codePushReportingManager.reportStatus(new StatusReport(ReportingStatus.STORE_VERSION, null, appVersion, mainWebView.getPreferences().getString(DEPLOYMENT_KEY_PREFERENCE, null)), this.mainWebView);
@@ -270,6 +270,44 @@ public class CodePush extends CordovaPlugin {
         }
     }
 
+    private void clearDeploymentsIfBinaryUpdated() {
+        /* check if we have a deployed package already */
+        CodePushPackageMetadata deployedPackageMetadata = this.codePushPackageManager.getCurrentPackageMetadata();
+        if (deployedPackageMetadata != null) {
+            String deployedPackageTimeStamp = deployedPackageMetadata.nativeBuildTime;
+            long nativeBuildTime = Utilities.getApkEntryBuildTime(RESOURCES_BUNDLE, this.cordova.getActivity());
+            if (nativeBuildTime != -1) {
+                String currentAppTimeStamp = String.valueOf(nativeBuildTime);
+                if ((deployedPackageTimeStamp != null) && (currentAppTimeStamp != null)) {
+                    if (!deployedPackageTimeStamp.equals(currentAppTimeStamp)) {
+                        this.codePushPackageManager.cleanDeployments();
+                        this.codePushPackageManager.clearFailedUpdates();
+                        this.codePushPackageManager.clearPendingInstall();
+                        this.codePushPackageManager.clearInstallNeedsConfirmation();
+                        this.codePushPackageManager.clearBinaryFirstRunFlag();
+                    }
+                }
+            }
+        }
+    }
+
+    private void navigateToLocalDeploymentIfExists() {
+        CodePushPackageMetadata deployedPackageMetadata = this.codePushPackageManager.getCurrentPackageMetadata();
+        if (deployedPackageMetadata != null) {
+            if (deployedPackageMetadata.localPath != null) {
+                File startPage = this.getStartPageForPackage(deployedPackageMetadata.localPath);
+                if (startPage != null) {
+                    /* file exists */
+                    try {
+                        navigateToFile(startPage);
+                    } catch (MalformedURLException e) {
+                    /* empty - if there is an exception, the app will launch with the bundled content */
+                    }
+                }
+            }
+        }
+    }
+
     private boolean execPreInstall(CordovaArgs args, CallbackContext callbackContext) {
     /* check if package is valid */
         try {
@@ -314,47 +352,6 @@ public class CodePush extends CordovaPlugin {
             callbackContext.success(result);
         } else {
             callbackContext.error("Could not get preference: " + preferenceName);
-        }
-    }
-
-    private void handleAppStart() {
-        try {
-            /* check if we have a deployed package already */
-            CodePushPackageMetadata deployedPackageMetadata = this.codePushPackageManager.getCurrentPackageMetadata();
-            if (deployedPackageMetadata != null) {
-                String deployedPackageTimeStamp = deployedPackageMetadata.nativeBuildTime;
-                long nativeBuildTime = Utilities.getApkEntryBuildTime(RESOURCES_BUNDLE, this.cordova.getActivity());
-                if (nativeBuildTime != -1) {
-                    String currentAppTimeStamp = String.valueOf(nativeBuildTime);
-                    if ((deployedPackageTimeStamp != null) && (currentAppTimeStamp != null)) {
-                        if (deployedPackageTimeStamp.equals(currentAppTimeStamp)) {
-                            /* same native version, safe to launch from local storage */
-                            if (deployedPackageMetadata.localPath != null) {
-                                File startPage = this.getStartPageForPackage(deployedPackageMetadata.localPath);
-                                if (startPage != null) {
-                                    /* file exists */
-                                    navigateToFile(startPage);
-                                }
-                            }
-                        } else {
-                            /* application updated in the store or via local deployment */
-                            this.codePushPackageManager.cleanDeployments();
-                            this.codePushPackageManager.clearFailedUpdates();
-                            this.codePushPackageManager.clearPendingInstall();
-                            this.codePushPackageManager.clearInstallNeedsConfirmation();
-                            try {
-                                String appVersion = Utilities.getAppVersionName(cordova.getActivity());
-                                codePushReportingManager.reportStatus(new StatusReport(ReportingStatus.STORE_VERSION, null, appVersion, mainWebView.getPreferences().getString(DEPLOYMENT_KEY_PREFERENCE, null)), this.mainWebView);
-                            } catch (PackageManager.NameNotFoundException e) {
-                                // Should not happen unless the appVersion is not specified, in which case we can't report anything anyway.
-                                e.printStackTrace();
-                            }
-                        }
-                    }
-                }
-            }
-        } catch (Exception e) {
-            /* empty - if there is an exception, the app will launch with the bundled content */
         }
     }
 
@@ -468,6 +465,7 @@ public class CodePush extends CordovaPlugin {
      */
     @Override
     public void onStart() {
+        clearDeploymentsIfBinaryUpdated();
         if (!didStartApp) {
             /* The application was just started. */
             didStartApp = true;
@@ -478,7 +476,7 @@ public class CodePush extends CordovaPlugin {
                 handleUnconfirmedInstall(false);
             }
 
-            handleAppStart();
+            navigateToLocalDeploymentIfExists();
             /* Handle ON_NEXT_RESUME and ON_NEXT_RESTART pending installations */
             if (pendingInstall != null && (InstallMode.ON_NEXT_RESUME.equals(pendingInstall.installMode) || InstallMode.ON_NEXT_RESTART.equals(pendingInstall.installMode))) {
                 this.markUpdate();
@@ -490,7 +488,7 @@ public class CodePush extends CordovaPlugin {
             InstallOptions pendingInstall = this.codePushPackageManager.getPendingInstall();
             long durationInBackground = (new Date().getTime() - lastPausedTimeMs) / 1000;
             if (pendingInstall != null && InstallMode.ON_NEXT_RESUME.equals(pendingInstall.installMode) && durationInBackground >= pendingInstall.minimumBackgroundDuration) {
-                handleAppStart();
+                navigateToLocalDeploymentIfExists();
                 this.markUpdate();
                 this.codePushPackageManager.clearPendingInstall();
             } else if (codePushReportingManager.hasFailedReport()) {

--- a/src/android/CodePushPackageManager.java
+++ b/src/android/CodePushPackageManager.java
@@ -116,11 +116,15 @@ public class CodePushPackageManager {
         return this.codePushPreferences.installNeedsConfirmation();
     }
 
-    public boolean isFirstRun() {
-        return this.codePushPreferences.isFirstRun();
+    public boolean isBinaryFirstRun() {
+        return this.codePushPreferences.isBinaryFirstRun();
     }
 
-    public void saveFirstRunFlag() {
-        this.codePushPreferences.saveFirstRunFlag();
+    public void clearBinaryFirstRunFlag() {
+        this.codePushPreferences.clearBinaryFirstRunFlag();
+    }
+
+    public void saveBinaryFirstRunFlag() {
+        this.codePushPreferences.saveBinaryFirstRunFlag();
     }
 }

--- a/src/android/CodePushPreferences.java
+++ b/src/android/CodePushPreferences.java
@@ -118,14 +118,21 @@ public class CodePushPreferences {
         return notConfirmedInstall;
     }
 
-    public void saveFirstRunFlag() {
+    public void clearBinaryFirstRunFlag() {
+        SharedPreferences preferences = context.getSharedPreferences(CodePushPreferences.FIRST_RUN_PREFERENCE, Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = preferences.edit();
+        editor.remove(CodePushPreferences.FIRST_RUN_PREFERENCE_KEY);
+        editor.commit();
+    }
+
+    public void saveBinaryFirstRunFlag() {
         SharedPreferences preferences = context.getSharedPreferences(CodePushPreferences.FIRST_RUN_PREFERENCE, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = preferences.edit();
         editor.putBoolean(CodePushPreferences.FIRST_RUN_PREFERENCE_KEY, false);
         editor.commit();
     }
 
-    public boolean isFirstRun() {
+    public boolean isBinaryFirstRun() {
         SharedPreferences preferences = context.getSharedPreferences(CodePushPreferences.FIRST_RUN_PREFERENCE, Context.MODE_PRIVATE);
         boolean isFirstRun = preferences.getBoolean(CodePushPreferences.FIRST_RUN_PREFERENCE_KEY, true);
         return isFirstRun;

--- a/src/ios/CodePush.m
+++ b/src/ios/CodePush.m
@@ -233,7 +233,7 @@ StatusReport* rollbackStatusReport = nil;
 
         if (deployedPackageNativeBuildTime != nil && applicationBuildTime != nil) {
             if (![deployedPackageNativeBuildTime isEqualToString: applicationBuildTime]) {
-                // installed native version is different from package version
+                // package version is incompatible with installed native version
                 [CodePushPackageManager cleanDeployments];
                 [CodePushPackageManager clearFailedUpdates];
                 [CodePushPackageManager clearPendingInstall];
@@ -245,7 +245,6 @@ StatusReport* rollbackStatusReport = nil;
 }
 
 - (void)navigateToLocalDeploymentIfExists {
-    // check if we have a deployed package
     CodePushPackageMetadata* deployedPackageMetadata = [CodePushPackageManager getCurrentPackageMetadata];
     if (deployedPackageMetadata && deployedPackageMetadata.localPath) {
         [self redirectStartPageToURL: deployedPackageMetadata.localPath];

--- a/src/ios/CodePushPackageManager.h
+++ b/src/ios/CodePushPackageManager.h
@@ -17,7 +17,8 @@
 + (void)markInstallNeedsConfirmation;
 + (BOOL)installNeedsConfirmation;
 + (void)clearInstallNeedsConfirmation;
-+ (void)markFirstRunFlag;
-+ (BOOL)isFirstRun;
++ (void)clearBinaryFirstRunFlag;
++ (void)markBinaryFirstRunFlag;
++ (BOOL)isBinaryFirstRun;
 
 @end

--- a/src/ios/CodePushPackageManager.m
+++ b/src/ios/CodePushPackageManager.m
@@ -8,7 +8,7 @@ NSString* const BinaryHashKey = @"BINARY_HASH";
 NSString* const FailedUpdatesKey = @"FAILED_UPDATES";
 NSString* const PendingInstallKey = @"PENDING_INSTALL";
 NSString* const NotConfirmedInstallKey = @"NOT_CONFIRMED_INSTALL";
-NSString* const IsFirstRunKey = @"FIRST_RUN";
+NSString* const IsBinaryFirstRunKey = @"FIRST_RUN";
 NSString* const OldPackageManifestName = @"oldPackage.json";
 NSString* const CurrentPackageManifestName = @"currentPackage.json";
 
@@ -120,15 +120,21 @@ NSString* const CurrentPackageManifestName = @"currentPackage.json";
     [preferences removeObjectForKey:PendingInstallKey];
 }
 
-+ (void)markFirstRunFlag {
++ (void)clearBinaryFirstRunFlag {
     NSUserDefaults* preferences = [NSUserDefaults standardUserDefaults];
-    [preferences setBool:YES forKey:IsFirstRunKey];
+    [preferences removeObjectForKey:IsBinaryFirstRunKey];
     [preferences synchronize];
 }
 
-+ (BOOL)isFirstRun {
++ (void)markBinaryFirstRunFlag {
     NSUserDefaults* preferences = [NSUserDefaults standardUserDefaults];
-    BOOL firstRunFlagSet = [preferences boolForKey:IsFirstRunKey];
+    [preferences setBool:YES forKey:IsBinaryFirstRunKey];
+    [preferences synchronize];
+}
+
++ (BOOL)isBinaryFirstRun {
+    NSUserDefaults* preferences = [NSUserDefaults standardUserDefaults];
+    BOOL firstRunFlagSet = [preferences boolForKey:IsBinaryFirstRunKey];
     return !firstRunFlagSet;
 }
 

--- a/www/codePush.ts
+++ b/www/codePush.ts
@@ -65,7 +65,7 @@ class CodePush implements CodePushCordovaPlugin {
     public reportStatus(status: number, label: string, appVersion: string, deploymentKey: string, previousLabelOrAppVersion?: string, previousDeploymentKey?: string) {
        if ((!label || label === previousLabelOrAppVersion) &&
            appVersion === previousLabelOrAppVersion &&
-           deploymentKey == previousDeploymentKey) {
+           deploymentKey === previousDeploymentKey) {
            // No-op since the new appVersion and label is exactly the same as the previous
            // (the app might have been updated via a direct or HockeyApp deployment).
            return;

--- a/www/codePush.ts
+++ b/www/codePush.ts
@@ -63,9 +63,8 @@ class CodePush implements CodePushCordovaPlugin {
      * !!! This function is called from the native side, please make changes accordingly. !!!
      */
     public reportStatus(status: number, label: string, appVersion: string, deploymentKey: string, previousLabelOrAppVersion?: string, previousDeploymentKey?: string) {
-       if ((!label || label === previousLabelOrAppVersion) &&
-           appVersion === previousLabelOrAppVersion &&
-           deploymentKey === previousDeploymentKey) {
+       if (((!label && appVersion === previousLabelOrAppVersion) || label === previousLabelOrAppVersion)
+           && deploymentKey === previousDeploymentKey) {
            // No-op since the new appVersion and label is exactly the same as the previous
            // (the app might have been updated via a direct or HockeyApp deployment).
            return;

--- a/www/codePush.ts
+++ b/www/codePush.ts
@@ -63,6 +63,14 @@ class CodePush implements CodePushCordovaPlugin {
      * !!! This function is called from the native side, please make changes accordingly. !!!
      */
     public reportStatus(status: number, label: string, appVersion: string, deploymentKey: string, previousLabelOrAppVersion?: string, previousDeploymentKey?: string) {
+       if ((!label || label === previousLabelOrAppVersion) &&
+           appVersion === previousLabelOrAppVersion &&
+           deploymentKey == previousDeploymentKey) {
+           // No-op since the new appVersion and label is exactly the same as the previous
+           // (the app might have been updated via a direct or HockeyApp deployment).
+           return;
+       }
+
        var createPackageForReporting = (label: string, appVersion: string): IPackage => {
             return {
                 /* The SDK only reports the label and appVersion.


### PR DESCRIPTION
Couple of changes in this PR: 

- Renamed `codePushPackageManager.xxFirstRun()` methods to `codePushPackageManager.xxBinaryFirstRun()` to better reflect what those methods do and prevent confusion with the `isFirstRun` flag on our update metadata.

- Removed the call to `reportStatus` in app start (previously in `handleAppStart`), because it was causing crashes on Android whenever a rollback occurs on app start. Instead, delayed the `reportStatus` calls to `notifyApplicationReady` using the `xxBinaryFirstRun()` mechanisms already in place, that way its all the `reportStatus` calls are now in one place.

- Split up the `handleAppStart` method into `clearDeploymentsIfBinaryUpdated` and `navigateToLocalDeploymentIfExists` methods. This is needed in order to fix #126, which causes a crash when `handleUnconfirmedInstall` tries to rollback a "pending" update which unknowingly got cleared by `handleAppStart`. By splitting it up, we now can always call `clearDeploymentsIfBinaryUpdated` before all the other app initialization logic, which prevents us from getting "pending" information that is actually outdated and needs to be cleared.

- Added logic in JS `reportStatus` to no-op if the appVersion and label of the new update report is identical with the old update, which could happen whenever a new binary is deployed directly to the device, or when another app deployment service like HockeyApp updates the app without bumping the binary version.