### PR TITLE
fix device list parsing issue

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -217,7 +217,6 @@ gulp.task("tslint", function () {
 });
 
 gulp.task("clean", function () {
-    var del = require("del");
     return del([binPath + "/**"], { force: true });
 });
 

--- a/test/testUtil.ts
+++ b/test/testUtil.ts
@@ -110,7 +110,8 @@ export class TestUtil {
         } else {
             // get the most recent iOS simulator to run tests on
             this.getProcessOutput("xcrun simctl list")
-                .then(function (listOfDevices) {
+                .then(function (listOfDevicesWithDevicePairs) {
+                    var listOfDevices: string = listOfDevicesWithDevicePairs.slice(0, listOfDevicesWithDevicePairs.indexOf("== Device Pairs =="));
                     var phoneDevice = /iPhone (\S* )*(\(([0-9A-Z-]*)\))/g;
                     var match = listOfDevices.match(phoneDevice);
                     onReadIOSEmuName(match[match.length - 1]);

--- a/test/testUtil.ts
+++ b/test/testUtil.ts
@@ -111,7 +111,7 @@ export class TestUtil {
             // get the most recent iOS simulator to run tests on
             this.getProcessOutput("xcrun simctl list")
                 .then(function (listOfDevicesWithDevicePairs) {
-                    var listOfDevices: string = listOfDevicesWithDevicePairs.slice(0, listOfDevicesWithDevicePairs.indexOf("== Device Pairs =="));
+                    var listOfDevices: string = listOfDevicesWithDevicePairs.slice(listOfDevicesWithDevicePairs.indexOf("-- iOS"), listOfDevicesWithDevicePairs.indexOf("-- tvOS"));
                     var phoneDevice = /iPhone (\S* )*(\(([0-9A-Z-]*)\))/g;
                     var match = listOfDevices.match(phoneDevice);
                     onReadIOSEmuName(match[match.length - 1]);


### PR DESCRIPTION
the parsing was including the device pairs as well as the regular devices, which would cause the booting of the simulator to fail and thus failing our automated tests occasionally.

the plugin testing framework has been updated with this change, but this is a hotfix until OSS approves it.