### PR TITLE
getAcquisitionManager: specific error if no version in config.xml

### DIFF
--- a/www/sdk.ts
+++ b/www/sdk.ts
@@ -44,7 +44,9 @@ class Sdk {
             NativeAppInfo.getServerURL((serverError: Error, serverURL: string) => {
                 NativeAppInfo.getDeploymentKey((depolymentKeyError: Error, deploymentKey: string) => {
                     NativeAppInfo.getApplicationVersion((appVersionError: Error, appVersion: string) => {
-                        if (!serverURL || !appVersion) {
+                        if (!appVersion) {
+                            callback(new Error("Could not get the app version. Please check your config.xml file."), null);
+                        } else if (!serverURL) {
                             callback(new Error("Could not get the CodePush configuration. Please check your config.xml file."), null);
                         } else {
                             Sdk.DefaultConfiguration = {


### PR DESCRIPTION
I'm generating a config.xml in my project for each environment, and it turns out my config.xml generation script wasn't specifying the version correctly.

I wasted a lot of time today because of the vague error that was thrown when appVersion isn't found.

Hopefully this more specific error will save someone else some time.
