### PR TITLE
Fixing header (iOS)

### DIFF
--- a/src/ios/CodePush.h
+++ b/src/ios/CodePush.h
@@ -11,9 +11,7 @@
 - (void)isFailedUpdate:(CDVInvokedUrlCommand *)command;
 - (void)isFirstRun:(CDVInvokedUrlCommand *)command;
 - (void)isPendingUpdate:(CDVInvokedUrlCommand *)command;
-- (void)updateSuccess:(CDVInvokedUrlCommand *)command;
 - (void)restartApplication:(CDVInvokedUrlCommand *)command;
 - (void)pluginInitialize;
 
 @end
-


### PR DESCRIPTION
The `updateSuccess` method was removed from the `CodePush` class in `v1.8.0`, and this PR simply removes it from the corresponding header file so that Xcode doesn't display a warning about it not being implemented.