### PR TITLE
Backgrounding expensive operations (iOS)

### DIFF
--- a/src/ios/CodePush.m
+++ b/src/ios/CodePush.m
@@ -24,17 +24,17 @@ StatusReport* rollbackStatusReport = nil;
         NSString* binaryHash = [CodePushPackageManager getCachedBinaryHash];
         if (binaryHash) {
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
-                                            messageAsString:binaryHash];
+                                             messageAsString:binaryHash];
         } else {
             NSError* error;
             binaryHash = [UpdateHashUtils getBinaryHash:&error];
             if (error) {
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
-                                                messageAsString:[@"An error occurred when trying to get the hash of the binary contents. " stringByAppendingString:error.description]];
+                                                 messageAsString:[@"An error occurred when trying to get the hash of the binary contents. " stringByAppendingString:error.description]];
             } else {
                 [CodePushPackageManager saveBinaryHash:binaryHash];
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
-                                                messageAsString:binaryHash];
+                                                 messageAsString:binaryHash];
             }
         }
 
@@ -71,29 +71,29 @@ StatusReport* rollbackStatusReport = nil;
             NSString* appVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
             NSString* deploymentKey = ((CDVViewController *)self.viewController).settings[DeploymentKeyPreference];
             StatusReport* statusReport = [[StatusReport alloc] initWithStatus:STORE_VERSION
-                                                                    andLabel:nil
+                                                                     andLabel:nil
                                                                 andAppVersion:appVersion
-                                                            andDeploymentKey:deploymentKey];
+                                                             andDeploymentKey:deploymentKey];
             [CodePushReportingManager reportStatus:statusReport
-                                    withWebView:self.webView];
+                                       withWebView:self.webView];
         } else if ([CodePushPackageManager installNeedsConfirmation]) {
             // Report CodePush update installation that has not been confirmed yet
             CodePushPackageMetadata* currentMetadata = [CodePushPackageManager getCurrentPackageMetadata];
             StatusReport* statusReport = [[StatusReport alloc] initWithStatus:UPDATE_CONFIRMED
-                                                                    andLabel:currentMetadata.label
+                                                                     andLabel:currentMetadata.label
                                                                 andAppVersion:currentMetadata.appVersion
-                                                            andDeploymentKey:currentMetadata.deploymentKey];
+                                                             andDeploymentKey:currentMetadata.deploymentKey];
             [CodePushReportingManager reportStatus:statusReport
                                     withWebView:self.webView];
         } else if (rollbackStatusReport) {
             // Report a CodePush update that rolled back
             [CodePushReportingManager reportStatus:rollbackStatusReport
-                                    withWebView:self.webView];
+                                       withWebView:self.webView];
             rollbackStatusReport = nil;
         } else if ([CodePushReportingManager hasFailedReport]) {
             // Previous status report failed, so try it again
             [CodePushReportingManager reportStatus:[CodePushReportingManager getAndClearFailedReport]
-                                    withWebView:self.webView];
+                                       withWebView:self.webView];
         }
 
         // Mark the update as confirmed and not requiring a rollback


### PR DESCRIPTION
This addresses https://github.com/Microsoft/code-push/issues/256 by ensuring that expensive native operations are offloaded to a background thread. I modified the Cordova warning threshold to 1ms (instead of 10) for testing purposes, and moved all methods that took longer than that off of the UI thread. The biggest contributors were `getBinaryHash` and `notifyApplicationReady`, both of which were ~15ms+, which definitely shouldn't be done on the UI thread. The `preInstall` and `install` methods were steadily around 2ms as well, so I decided to offload them even though they aren't as impactful. All other methods were sub-millisecond, so I decided not to go crazy with this PR (even though our React Native plugin runs all native code on a background thread). We can always improve this later as needed.

The churn below is as a result of the "wrapping" that the background thread code introduces. The basic structure of my changes are the following (based on [Cordova guidelines](https://cordova.apache.org/docs/en/latest/guide/platforms/ios/plugin.html#threading)), and impacts the aforementioned four methods:

```objective-c
[self.commandDelegate runInBackground:^{
    // Existing code here
}];
```
Note that I didn't look into Android at all, since I wanted to address the user-reported iOS issue specifically first. We can investigate Android optimization opportunities separately.