### PR TITLE
WKWebView fix

### DIFF
--- a/src/ios/CodePush.m
+++ b/src/ios/CodePush.m
@@ -311,9 +311,12 @@ StatusReport* rollbackStatusReport = nil;
 }
 
 - (void)loadURL:(NSURL*)url {
-    // Cast to a UIWebView here to enable call to loadRequest.
-    // Both UIWebView and WKWebview share this call, so regardless of which type the returned webview is, this will work.
-    [(UIWebView*)self.webView loadRequest:[NSURLRequest requestWithURL:url]];
+    if ([self respondsToSelector:@selector(webViewEngine)]) {
+        id webViewEngine = [self performSelector:@selector(webViewEngine)];
+        [webViewEngine performSelector:@selector(loadRequest:) withObject:[NSURLRequest requestWithURL:url]];
+    } else {
+        [(UIWebView*)self.webView loadRequest:[NSURLRequest requestWithURL:url]];
+    }
 }
 
 - (void)loadStoreVersion {

--- a/src/ios/CodePushReportingManager.m
+++ b/src/ios/CodePushReportingManager.m
@@ -35,7 +35,11 @@ NSString* const LastVersionPreferenceLabelOrAppVersionKey = @"LAST_VERSION_LABEL
         if ([webView respondsToSelector:@selector(evaluateJavaScript:completionHandler:)]) {
             [webView performSelector:@selector(evaluateJavaScript:completionHandler:) withObject:script withObject: NULL];
         } else if ([webView isKindOfClass:[UIWebView class]]) {
-            [(UIWebView*)webView stringByEvaluatingJavaScriptFromString:script];
+            // The UIWebView requires JS evaluation to occur on the main
+            // thread, so ensure that we dispatch to it before executing.
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [(UIWebView*)webView stringByEvaluatingJavaScriptFromString:script];
+            });
         }
     }
 }


### PR DESCRIPTION
This fixes #137 by using the `WebViewEngine` to navigate the WebView instead of using the deprecated `loadRequest:` method on the UI/WKWebView class (which enforces new security rules in iOS 9.3+). The `webViewEngine` property was only added in Cordova iOS 4.0.0, and our plugin currently supports 3.9.0+, which is why I'm using `performSelector`/`id` type to actually perform the navigation. At some point, it might make sense for us to just start requiring 4.0.0+, at which point we can clean this code up. For now though, I don't want to change our platform compatibility.

Additionally, this fixes a regression I caused with #142. I had only tested that fix with `WKWebView` and it turns out that the `UIWebView` requires you to execute JS from the UI thread, so I need to ensure that we dispatch that call when the app is using the `UIWebView`.

I tested this thoroughly with Cordova iOS 3.9.0, and Cordova iOS 4.1.1, with both the `UIWebView` and `WKWebView` and everything works beautifully.