### PR TITLE
Fixing PhoneGap Build issue

### DIFF
--- a/src/ios/CodePush.m
+++ b/src/ios/CodePush.m
@@ -313,8 +313,8 @@ StatusReport* rollbackStatusReport = nil;
 - (void)loadURL:(NSURL*)url {
     // In order to make use of the "modern" Cordova platform, while still
     // maintaining back-compat with Cordova iOS 3.9.0, we need to conditionally
-    // use the WebViewEngine for performing navigations, only if the host app
-    // is running 4.0.0+, and fallback to using the WebView directly otherwise.
+    // use the WebViewEngine for performing navigations only if the host app
+    // is running 4.0.0+, and fallback to directly using the WebView otherwise.
 #ifdef __CORDOVA_4_0_0
     [self.webViewEngine loadRequest:[NSURLRequest requestWithURL:url]];
 #else

--- a/src/ios/CodePush.m
+++ b/src/ios/CodePush.m
@@ -311,12 +311,15 @@ StatusReport* rollbackStatusReport = nil;
 }
 
 - (void)loadURL:(NSURL*)url {
-    if ([self respondsToSelector:@selector(webViewEngine)]) {
-        id webViewEngine = [self performSelector:@selector(webViewEngine)];
-        [webViewEngine performSelector:@selector(loadRequest:) withObject:[NSURLRequest requestWithURL:url]];
-    } else {
-        [(UIWebView*)self.webView loadRequest:[NSURLRequest requestWithURL:url]];
-    }
+    // In order to make use of the "modern" Cordova platform, while still
+    // maintaining back-compat with Cordova iOS 3.9.0, we need to conditionally
+    // use the WebViewEngine for performing navigations, only if the host app
+    // is running 4.0.0+, and fallback to using the WebView directly otherwise.
+#ifdef __CORDOVA_4_0_0
+    [self.webViewEngine loadRequest:[NSURLRequest requestWithURL:url]];
+#else
+    [(UIWebView*)self.webView loadRequest:[NSURLRequest requestWithURL:url]];
+#endif
 }
 
 - (void)loadStoreVersion {


### PR DESCRIPTION
This PR fixes https://github.com/Microsoft/code-push/issues/268 by removing the runtime resolution of the `loadRequest:` selector, which can in some circumstances be ambitious due to their being multiple "versions" of this method available. Instead, we can perform the `WebViewEngine` vs. `WebView` check at compile-time, based on whether or not the host app is running Cordova iOS 4.0.0+, and then call the right `loadRequest:` method directly on each type, so that we don't need dynamic runtime resolution anyways.