### PR TITLE
Add `cordovaDependencies` section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,18 @@
       "ios"
     ]
   },
+  "engines": {
+    "cordovaDependencies": {
+      "1.8.x": {
+        "cordova": ">=5.0.0",
+        "cordova-android": ">=4.0.0",
+        "cordova-ios": ">=3.9.0"
+      },
+      "2.0.0": {
+        "cordova": ">=100"
+      }
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Microsoft/cordova-plugin-code-push"


### PR DESCRIPTION
This PR adds `engines` element to package.json based on [plugin documentation](https://github.com/Microsoft/cordova-plugin-code-push/blob/master/README.md#supported-cordova-platforms) to comply w/ [new cordova plugin fetching model](https://github.com/cordova/cordova-discuss/blob/master/proposals/plugin-version-fetching.md).

This also adds a 'protective' entry for next major plugin version to protect end-users from fetching edge versions of the plugin by incompatible version of cordova. See corresponding [discussion on mailing list](http://apache.markmail.org/thread/p73loqtvbzvfzsv5) for more details and reasons behind this.