### PR TITLE
Tidy master

### DIFF
--- a/bin/www/sdk.js
+++ b/bin/www/sdk.js
@@ -42,7 +42,10 @@ var Sdk = (function () {
             NativeAppInfo.getServerURL(function (serverError, serverURL) {
                 NativeAppInfo.getDeploymentKey(function (depolymentKeyError, deploymentKey) {
                     NativeAppInfo.getApplicationVersion(function (appVersionError, appVersion) {
-                        if (!serverURL || !appVersion) {
+                        if (!appVersion) {
+                            callback(new Error("Could not get the app version. Please check your config.xml file."), null);
+                        }
+                        else if (!serverURL) {
                             callback(new Error("Could not get the CodePush configuration. Please check your config.xml file."), null);
                         }
                         else {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,6 @@ var tsCompileOptions = {
     "target": "ES5",
     "module": "commonjs",
     "sourceMap": false,
-    "sortOutput": true,
     "removeComments": true
 };
 
@@ -41,7 +40,7 @@ function spawnCommand(command, args, callback, silent, detached) {
         options.detached = true;
         options.stdio = ["ignore"];
     }
-    
+
     var process = child_process.spawn(command, args, options);
 
     process.stdout.on('data', function (data) {
@@ -57,7 +56,7 @@ function spawnCommand(command, args, callback, silent, detached) {
             callback && callback(code === 0 ? undefined : "Error code: " + code);
         });
     }
-    
+
     return process;
 };
 
@@ -71,15 +70,15 @@ function execCommand(command, args, callback, silent) {
     process.stderr.on('data', function (data) {
         if (!silent) console.error("" + data);
     });
-    
+
     process.on('error', function (error) {
         callback && callback(error);
     })
-    
+
     process.on('exit', function (code) {
         callback && callback(code === 0 ? undefined : "Error code: " + code);
     });
-    
+
     return process;
 };
 
@@ -114,11 +113,11 @@ function execCommandWithPromise(command, options, logOutput) {
 function runTests(callback, options) {
     var command = "node_modules/.bin/mocha";
     var args = ["./bin/test"];
-    
+
     // Set up the mocha junit reporter.
     args.push("--reporter");
     args.push("mocha-junit-reporter");
-    
+
     // Set the mocha reporter to the correct output file.
     args.push("--reporter-options");
     var filename = "./test-results.xml";
@@ -127,7 +126,7 @@ function runTests(callback, options) {
     args.push("mochaFile=" + filename);
     // Delete previous test result file so TFS doesn't read the old file if the tests exit before saving
     del(filename);
-    
+
     // Pass arguments supplied by test tasks.
     if (options.android) args.push("--android");
     if (options.ios) {
@@ -136,13 +135,13 @@ function runTests(callback, options) {
         args.push(options.wk ? (options.ui ? "both" : "true") : "false");
     }
     if (options.setup) args.push("--setup");
-    
+
     // Pass arguments from command line.
     // The fourth argument is the first argument after the task name.
     for (var i = 3; i < process.argv.length; i++) {
         args.push(process.argv[i]);
     }
-    
+
     execCommand(command, args, callback);
 }
 
@@ -212,8 +211,8 @@ gulp.task("tslint", function () {
     }
 
     return gulp.src([sourcePath + tsFiles, testPath + tsFiles])
-        .pipe(tslint({ configuration: config }))
-        .pipe(tslint.report("verbose"));
+        .pipe(tslint({ configuration: config, formatter: "verbose" }))
+        .pipe(tslint.report());
 });
 
 gulp.task("clean", function () {
@@ -238,7 +237,7 @@ gulp.task("test-run-android", function (callback) {
     var options = {
         android: true
     };
-    
+
     runTests(callback, options);
 });
 
@@ -248,7 +247,7 @@ gulp.task("test-run-ios-ui", function (callback) {
         ios: true,
         ui: true,
     };
-    
+
     runTests(callback, options);
 });
 
@@ -258,7 +257,7 @@ gulp.task("test-run-ios-wk", function (callback) {
         ios: true,
         wk: true,
     };
-    
+
     runTests(callback, options);
 });
 
@@ -274,7 +273,7 @@ gulp.task("test-setup-android", function (callback) {
         setup: true,
         android: true
     };
-    
+
     runTests(callback, options);
 });
 
@@ -284,7 +283,7 @@ gulp.task("test-setup-ios", function (callback) {
         setup: true,
         ios: true
     };
-    
+
     runTests(callback, options);
 });
 
@@ -295,7 +294,7 @@ gulp.task("test-setup-both", function (callback) {
         android: true,
         ios: true
     };
-    
+
     runTests(callback, options);
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,9 +18,8 @@ var emulatorMaxReadyAttempts = 5;
 var compiledSourceWarningMessage = "\n \
 /******************************************************************************************** \n \
 	 THIS FILE HAS BEEN COMPILED FROM TYPESCRIPT SOURCES. \n \
-	 PLEASE DO NOT MODIFY THIS FILE AS YOU WILL LOSE YOUR CHANGES WHEN RECOMPILING. \n \
-	 ALSO, PLEASE DO NOT SUBMIT PULL REQUESTS WITH CHANGES TO THIS FILE. \n \
-	 INSTEAD, EDIT THE TYPESCRIPT SOURCES UNDER THE WWW FOLDER. \n \
+	 PLEASE DO NOT MODIFY THIS FILE DIRECTLY AS YOU WILL LOSE YOUR CHANGES WHEN RECOMPILING. \n \
+	 INSTEAD, EDIT THE TYPESCRIPT SOURCES UNDER THE WWW FOLDER, AND THEN RUN GULP. \n \
 	 FOR MORE INFORMATION, PLEASE SEE CONTRIBUTING.md. \n \
 *********************************************************************************************/ \n\n\n";
 

--- a/package.json
+++ b/package.json
@@ -36,20 +36,21 @@
   "author": "Microsoft Corporation",
   "license": "MIT",
   "devDependencies": {
+    "archiver": "latest",
+    "body-parser": "latest",
+    "del": "latest",
+    "express": "latest",
     "gulp": "latest",
-    "gulp-typescript": "latest",
     "gulp-insert": "latest",
     "gulp-tslint": "latest",
-    "tslint": "latest",
-    "del": "latest",
-    "run-sequence": "latest",
+    "gulp-typescript": "latest",
+    "mkdirp": "latest",
+    "mocha": "latest",
+    "mocha-junit-reporter": "latest",
     "q": "latest",
     "replace": "latest",
-    "mkdirp": "latest",
-    "mocha" : "latest",
-    "mocha-junit-reporter" : "latest",
-    "express": "latest",
-    "body-parser": "latest",
-    "archiver": "latest"
+    "run-sequence": "latest",
+    "tslint": "latest",
+    "typescript": "latest"
   }
 }


### PR DESCRIPTION
The latest versions of our dev dependencies have some breaking changes, including requiring `typescript` to be installed in addition to the existing `gulp-typescript`, and an interface change in `tslint`.

This PR also updates the compiled js output, which was missing from a previous PR.