### PR TITLE
Send plugin version with requests

### DIFF
--- a/bin/www/httpRequester.js
+++ b/bin/www/httpRequester.js
@@ -33,6 +33,8 @@ var HttpRequester = (function () {
         if (this.contentType) {
             xhr.setRequestHeader("Content-Type", this.contentType);
         }
+        xhr.setRequestHeader("X-CodePush-Plugin-Name", "cordova-plugin-code-push");
+        xhr.setRequestHeader("X-CodePush-Plugin-Version", cordova.require("cordova/plugin_list").metadata["cordova-plugin-code-push"]);
         xhr.setRequestHeader("X-CodePush-SDK-Version", cordova.require("cordova/plugin_list").metadata["code-push"]);
         xhr.send(requestBody);
     };

--- a/samples/.gitignore
+++ b/samples/.gitignore
@@ -1,0 +1,2 @@
+*/platforms
+*/plugins

--- a/samples/advanced/config.xml
+++ b/samples/advanced/config.xml
@@ -9,7 +9,7 @@
         <content src="index.html" />
 
         <plugin name="cordova-plugin-whitelist" version="1" />
-        <plugin name="cordova-plugin-code-push" version="1.5.0-beta" />
+        <plugin name="cordova-plugin-code-push" spec="../.." />
 
         <!-- This sample application can communicate with any external domain.
          If you want to restrict this, don't forget to enable communication with the Code-Push server URL as well. -->

--- a/samples/basic/config.xml
+++ b/samples/basic/config.xml
@@ -9,7 +9,7 @@
         <content src="index.html" />
 
         <plugin name="cordova-plugin-whitelist" version="1" />
-        <plugin name="cordova-plugin-code-push" version="1.5.0-beta" />
+        <plugin name="cordova-plugin-code-push" spec="../.." />
 
         <!-- This sample application can communicate with any external domain.
          If you want to restrict this, don't forget to enable communication with the Code-Push server URL as well. -->

--- a/www/httpRequester.ts
+++ b/www/httpRequester.ts
@@ -40,6 +40,8 @@ class HttpRequester implements Http.Requester {
             xhr.setRequestHeader("Content-Type", this.contentType);
         }
 
+        xhr.setRequestHeader("X-CodePush-Plugin-Name", "cordova-plugin-code-push");
+        xhr.setRequestHeader("X-CodePush-Plugin-Version", cordova.require("cordova/plugin_list").metadata["cordova-plugin-code-push"]);
         xhr.setRequestHeader("X-CodePush-SDK-Version", cordova.require("cordova/plugin_list").metadata["code-push"]);
         xhr.send(requestBody);
     }


### PR DESCRIPTION
This is just a quick PR to send the plugin version as a header in requests to the CodePush server.

The acquisition SDK version currently being sent with requests is unreliable, because it is only updated rarely, and because it is shared with the React Native plugin.

Sending the actual `cordova-plugin-code-push` version allows the server to have fine-grained recognition of the exact plugin and version, and is necessary for breaking features such as the new CDN used to distribute updates.