### PR TITLE
Remove cordovaDependencies - does not work with pre-release versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,23 +9,6 @@
       "ios"
     ]
   },
-  "engines": {
-    "cordovaDependencies": {
-      "1.8.x": {
-        "cordova": ">=5.0.0",
-        "cordova-android": ">=4.0.0",
-        "cordova-ios": ">=3.9.0"
-      },
-      "1.9.x": {
-        "cordova": ">=5.0.0",
-        "cordova-android": ">=4.0.0",
-        "cordova-ios": ">=3.9.0"
-      },
-      "2.0.0": {
-        "cordova": ">=100"
-      }
-    }
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Microsoft/cordova-plugin-code-push"


### PR DESCRIPTION
Installation on VS fails because the `cordovaDependencies` resolution logic doesn't work with pre-release versions. Note that removing it will simply result in installation defaulting to the latest version. This should be acceptable, as it is highly unlikely at this point for a new user to be using a version of Cordova that we don't support, and even if they are, there is no version of our plugin that they would be able to use (and our docs do document this limitation clearly).