### PR TITLE
readme: fixed “updateTitle” prop usage in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ codePush.sync(null, { mandatoryInstallMode: InstallMode.ON_NEXT_RESUME });
 
 // Changing the title displayed in the
 // confirmation dialog of an "active" update
-codePush.sync(null, { updateDialog: { title: "An update is available!" } });
+codePush.sync(null, { updateDialog: { updateTitle: "An update is available!" } });
 
 // Displaying an update prompt which includes the
 // description associated with the CodePush release


### PR DESCRIPTION
Changed `codePush.sync(null, { updateDialog: { title: "An update is available!" } });`
to `codePush.sync(null, { updateDialog: { updateTitle: "An update is available!" } });`
due to there is no such property as `title` in `SyncOptions`.