### PR TITLE
fix typescript compile error in remotePackage.ts

### DIFF
--- a/bin/www/remotePackage.js
+++ b/bin/www/remotePackage.js
@@ -69,7 +69,7 @@ var RemotePackage = (function (_super) {
                         downloadProgress(dp);
                     }
                 };
-                this.currentFileTransfer.download(this.downloadUrl, cordova.file.dataDirectory + LocalPackage.DownloadDir + "/" + LocalPackage.PackageUpdateFileName, downloadSuccess, downloadError, true);
+                this.currentFileTransfer.download(this.downloadUrl, cordova.file.dataDirectory + LocalPackage.DownloadDir + "/" + LocalPackage.PackageUpdateFileName, downloadSuccess, downloadError, null, true);
             }
         }
         catch (e) {

--- a/www/remotePackage.ts
+++ b/www/remotePackage.ts
@@ -76,7 +76,7 @@ class RemotePackage extends Package implements IRemotePackage {
                     }
                 };
 
-                this.currentFileTransfer.download(this.downloadUrl, cordova.file.dataDirectory + LocalPackage.DownloadDir + "/" + LocalPackage.PackageUpdateFileName, downloadSuccess, downloadError, true);
+                this.currentFileTransfer.download(this.downloadUrl, cordova.file.dataDirectory + LocalPackage.DownloadDir + "/" + LocalPackage.PackageUpdateFileName, downloadSuccess, downloadError, null, true);
             }
         } catch (e) {
             CodePushUtil.invokeErrorCallback(new Error("An error occured while downloading the package. " + (e && e.message) ? e.message : ""), errorCallback);


### PR DESCRIPTION
After cloning the repository, then doing `npm install`, then `gulp`, the TS compilation failed with the error

```
www/remotePackage.ts(79,199): error TS2559: Type 'true' has no properties in common with type 'FileDownloadOptions'.
www/remotePackage.ts(79,199): error TS2559: Type 'true' has no properties in common with type 'FileDownloadOptions'.
```

Since the `noEmitOnError` TS compile option is set, this results in no JS files being emitted.

This commit fixes this by explicitly passing `null` for the `options` parameter, making the `true` be used for the `trustAllHosts` parameter, which is I believe what was intended.