### PR TITLE
implement code signing for iOS, package hash checking for iOS and Android

### DIFF
--- a/bin/www/localPackage.js
+++ b/bin/www/localPackage.js
@@ -47,40 +47,74 @@ var LocalPackage = (function (_super) {
                 _this.localPath = deployDir.fullPath;
                 _this.finishInstall(deployDir, installOptions, installSuccess, installError);
             };
-            var newPackageUnzipped = function (unzipError) {
-                if (unzipError) {
-                    installError && installError(new Error("Could not unzip package. " + CodePushUtil.getErrorMessage(unzipError)));
+            var newPackageUnzippedAndVerified = function (error) {
+                if (error) {
+                    installError && installError(new Error("Could not unzip and verify package. " + CodePushUtil.getErrorMessage(error)));
                 }
                 else {
                     LocalPackage.handleDeployment(newPackageLocation, CodePushUtil.getNodeStyleCallbackFor(donePackageFileCopy, installError));
                 }
             };
             FileUtil.getDataDirectory(LocalPackage.DownloadUnzipDir, false, function (error, directoryEntry) {
-                var unzipPackage = function () {
+                var unzipAndVerifyPackage = function () {
                     FileUtil.getDataDirectory(LocalPackage.DownloadUnzipDir, true, function (innerError, unzipDir) {
                         if (innerError) {
                             installError && installError(innerError);
+                            return;
                         }
-                        else {
-                            zip.unzip(_this.localPath, unzipDir.toInternalURL(), newPackageUnzipped);
-                        }
+                        zip.unzip(_this.localPath, unzipDir.toInternalURL(), function (unzipError) {
+                            if (unzipError) {
+                                installError && installError(new Error("Could not unzip package. " + CodePushUtil.getErrorMessage(unzipError)));
+                            }
+                            _this.verifyPackage(unzipDir, installError, newPackageUnzippedAndVerified);
+                        });
                     });
                 };
                 if (!error && !!directoryEntry) {
                     directoryEntry.removeRecursively(function () {
-                        unzipPackage();
+                        unzipAndVerifyPackage();
                     }, function (cleanupError) {
                         installError && installError(FileUtil.fileErrorToError(cleanupError));
                     });
                 }
                 else {
-                    unzipPackage();
+                    unzipAndVerifyPackage();
                 }
             });
         }
         catch (e) {
             installError && installError(new Error("An error occured while installing the package. " + CodePushUtil.getErrorMessage(e)));
         }
+    };
+    LocalPackage.prototype.verifyPackage = function (unzipDir, installError, callback) {
+        var _this = this;
+        var packageHashSuccess = function (localHash) {
+            FileUtil.readFile(cordova.file.dataDirectory, unzipDir.fullPath + '/www', '.codepushrelease', function (error, contents) {
+                var verifySignatureSuccess = function (expectedHash) {
+                    if (localHash !== _this.packageHash) {
+                        installError(new Error("package hash verification failed"));
+                        return;
+                    }
+                    if (!expectedHash) {
+                        callback(null, false);
+                        return;
+                    }
+                    if (localHash === expectedHash) {
+                        callback(null, true);
+                        return;
+                    }
+                    installError(new Error("package hash verification failed"));
+                };
+                var verifySignatureFail = function (error) {
+                    installError && installError(new Error("signature verification error: " + error));
+                };
+                cordova.exec(verifySignatureSuccess, verifySignatureFail, "CodePush", "verifySignature", [contents]);
+            });
+        };
+        var packageHashFail = function (error) {
+            installError && installError(new Error("unable to compute hash for package: " + error));
+        };
+        cordova.exec(packageHashSuccess, packageHashFail, "CodePush", "getPackageHash", [unzipDir.fullPath]);
     };
     LocalPackage.prototype.finishInstall = function (deployDir, installOptions, installSuccess, installError) {
         var _this = this;

--- a/plugin.xml
+++ b/plugin.xml
@@ -79,6 +79,7 @@
         </platform>
 
         <platform name="ios">
+            <framework src="JWT" type="podspec" spec="3.0.0-beta.4" />
             <source-file src="src/ios/CDVWKWebViewEngine+CodePush.m" />
             <header-file src="src/ios/CodePush.h" />
             <source-file src="src/ios/CodePush.m" />

--- a/src/android/CodePush.java
+++ b/src/android/CodePush.java
@@ -76,9 +76,25 @@ public class CodePush extends CordovaPlugin {
             return execReportSucceeded(args, callbackContext);
         } else if ("restartApplication".equals(action)) {
             return execRestartApplication(args, callbackContext);
+        } else if ("getPackageHash".equals(action)) {
+            return execGetPackageHash(args, callbackContext);
+        } else if ("verifySignature".equals(action)) {
+            return execVerifySignature(args, callbackContext);
         } else {
             return false;
         }
+    }
+
+    private boolean execVerifySignature(final CordovaArgs args, final CallbackContext callbackContext) {
+        new AsyncTask<Void, Void, Void>() {
+            @Override
+            protected Void doInBackground(Void... voids) {
+                // no actual code sign verification implemented for Android yet, just return null
+                callbackContext.success((String) null);
+                return null;
+            }
+        }.execute();
+        return true;
     }
 
     private boolean execGetBinaryHash(final CallbackContext callbackContext) {
@@ -104,6 +120,27 @@ public class CodePush extends CordovaPlugin {
             callbackContext.success(cachedBinaryHash);
         }
 
+        return true;
+    }
+
+    private boolean execGetPackageHash(final CordovaArgs args, final CallbackContext callbackContext) {
+        new AsyncTask<Void, Void, Void>() {
+            @Override
+            protected Void doInBackground(Void... params) {
+                try {
+                    String binaryHash = UpdateHashUtils.getHashForPath(cordova.getActivity(), args.getString(0) + "/www");
+                    callbackContext.success(binaryHash);
+                } catch (IOException e) {
+                    callbackContext.error("An error occurred when trying to get the hash of the binary contents. " + e.getMessage());
+                } catch (NoSuchAlgorithmException e) {
+                    callbackContext.error("An error occurred when trying to get the hash of the binary contents. " + e.getMessage());
+                } catch (JSONException e) {
+                    callbackContext.error("An error occurred when trying to get the hash of the binary contents. " + e.getMessage());
+                }
+
+                return null;
+            }
+        }.execute();
         return true;
     }
 

--- a/src/android/UpdateHashUtils.java
+++ b/src/android/UpdateHashUtils.java
@@ -6,22 +6,41 @@ import android.content.res.AssetManager;
 import org.json.JSONArray;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Utilities class used for native operations related to calculating hashes of update contents.
  */
 public class UpdateHashUtils {
+    private static final Set<String> ignoredFiles = new HashSet<String>(Arrays.asList(
+            ".codepushrelease",
+            ".DS_Store"
+    ));
 
     public static String getBinaryHash(Activity activity) throws IOException, NoSuchAlgorithmException {
+        return getHashForPath(activity, null);
+    }
+
+    public static String getHashForPath(Activity activity, String path) throws IOException, NoSuchAlgorithmException {
         ArrayList<String> manifestEntries = new ArrayList<String>();
-        addFolderEntriesToManifest(manifestEntries, "www", activity.getAssets());
+        if (path == null) {
+            addFolderEntriesToManifest(manifestEntries, "www", "www", activity.getAssets());
+        } else {
+            File basePath = activity.getApplicationContext().getFilesDir();
+            File fullPath = new File(basePath, path);
+            addFolderEntriesToManifest(manifestEntries, "www", fullPath.getPath(), null);
+        }
         Collections.sort(manifestEntries);
         JSONArray manifestJSONArray = new JSONArray();
         for (String manifestEntry : manifestEntries) {
@@ -33,16 +52,34 @@ public class UpdateHashUtils {
         return computeHash(new ByteArrayInputStream(manifestString.getBytes()));
     }
 
-    private static void addFolderEntriesToManifest(ArrayList<String> manifestEntries, String path, AssetManager assetManager) throws IOException, NoSuchAlgorithmException {
-        String[] fileList = assetManager.list(path);
-        if (fileList.length > 0) {
-            // This is a folder, recursively add folder entries to the manifest.
+    private static void addFolderEntriesToManifest(ArrayList<String> manifestEntries, String prefix, String path, AssetManager assetManager) throws IOException, NoSuchAlgorithmException {
+        String[] fileList;
+        if (assetManager != null) {
+            fileList = assetManager.list(path);
+        } else {
+            fileList = new File(path).list();
+        }
+        if (fileList != null && fileList.length > 0) {
             for (String pathInFolder : fileList) {
-                addFolderEntriesToManifest(manifestEntries, path + "/" + pathInFolder, assetManager);
+                if (UpdateHashUtils.ignoredFiles.contains(pathInFolder)) {
+                    continue;
+                }
+                File relativePath = new File(prefix, pathInFolder);
+                File absolutePath = new File(path, pathInFolder);
+                if (absolutePath.isDirectory()) {
+                    addFolderEntriesToManifest(manifestEntries, relativePath.getPath(), absolutePath.getPath(), assetManager);
+                } else {
+                    InputStream inputStream;
+                    if (assetManager != null) {
+                        inputStream = assetManager.open(relativePath.getPath());
+                    } else {
+                        inputStream = new FileInputStream(absolutePath.getPath());
+                    }
+                    manifestEntries.add(relativePath.getPath() + ":" + computeHash(inputStream));
+                }
             }
         } else {
-            // This is a file, compute a hash and create a manifest entry for it.
-            manifestEntries.add(path + ":" + computeHash(assetManager.open(path)));
+            throw new IOException("invalid directory path " + path);
         }
     }
 

--- a/src/ios/CodePush.h
+++ b/src/ios/CodePush.h
@@ -12,6 +12,9 @@
 - (void)isFirstRun:(CDVInvokedUrlCommand *)command;
 - (void)isPendingUpdate:(CDVInvokedUrlCommand *)command;
 - (void)restartApplication:(CDVInvokedUrlCommand *)command;
+- (void)getBinaryHash:(CDVInvokedUrlCommand *)command;
+- (void)getPackageHash:(CDVInvokedUrlCommand *)command;
+- (void)verifySignature:(CDVInvokedUrlCommand *)command;
 - (void)pluginInitialize;
 
 @end

--- a/src/ios/CodePush.m
+++ b/src/ios/CodePush.m
@@ -82,6 +82,16 @@ StatusReport* rollbackStatusReport = nil;
             return;
         }
 
+        // no .codepushrelease file in the update (or it couldn't be read)
+        if (!jwt || [jwt isEqualToString:@""]) {
+            [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                                                     messageAsString:@"\"Error! Public key was provided but there is no JWT signature within app bundle to verify.\n"
+                                                                             @"Possible reasons, why that might happen: \n"
+                                                                             @"You've released a CodePush bundle update using a version of CodePush CLI that does not support code signing.\n"
+                                                                             @"You've released a CodePush bundle update without providing the --privateKeyPath option."]
+                                        callbackId:command.callbackId];
+        }
+
         id <JWTAlgorithmDataHolderProtocol> verifyDataHolder = [JWTAlgorithmRSFamilyDataHolder new]
                 .keyExtractorType([JWTCryptoKeyExtractor publicKeyWithPEMBase64].type)
                 .algorithmName(@"RS256")

--- a/src/ios/UpdateHashUtils.h
+++ b/src/ios/UpdateHashUtils.h
@@ -1,5 +1,6 @@
 @interface UpdateHashUtils : NSObject
 
 + (NSString*)getBinaryHash:(NSError**)error;
++ (NSString*)getHashForPath:(NSString*)path error:(NSError**)error;
 
 @end

--- a/www/localPackage.ts
+++ b/www/localPackage.ts
@@ -71,39 +71,83 @@ class LocalPackage extends Package implements ILocalPackage {
                 this.finishInstall(deployDir, installOptions, installSuccess, installError);
             };
 
-            var newPackageUnzipped = (unzipError: any) => {
-                if (unzipError) {
-                    installError && installError(new Error("Could not unzip package. " + CodePushUtil.getErrorMessage(unzipError)));
+            var newPackageUnzippedAndVerified: Callback<boolean> = (error) => {
+                if (error) {
+                    installError && installError(new Error("Could not unzip and verify package. " + CodePushUtil.getErrorMessage(error)));
                 } else {
                     LocalPackage.handleDeployment(newPackageLocation, CodePushUtil.getNodeStyleCallbackFor<DirectoryEntry>(donePackageFileCopy, installError));
                 }
             };
 
             FileUtil.getDataDirectory(LocalPackage.DownloadUnzipDir, false, (error: Error, directoryEntry: DirectoryEntry) => {
-                var unzipPackage = () => {
+                var unzipAndVerifyPackage = () => {
                     FileUtil.getDataDirectory(LocalPackage.DownloadUnzipDir, true, (innerError: Error, unzipDir: DirectoryEntry) => {
                         if (innerError) {
                             installError && installError(innerError);
-                        } else {
-                            zip.unzip(this.localPath, unzipDir.toInternalURL(), newPackageUnzipped);
+                            return;
                         }
+
+                        zip.unzip(this.localPath, unzipDir.toInternalURL(), (unzipError: any) => {
+                            if (unzipError) {
+                                installError && installError(new Error("Could not unzip package. " + CodePushUtil.getErrorMessage(unzipError)));
+                            }
+                           this.verifyPackage(unzipDir, installError, newPackageUnzippedAndVerified);
+                        });
+
                     });
                 };
 
                 if (!error && !!directoryEntry) {
                     /* Unzip directory not clean */
                     directoryEntry.removeRecursively(() => {
-                        unzipPackage();
+                        unzipAndVerifyPackage();
                     }, (cleanupError: FileError) => {
                         installError && installError(FileUtil.fileErrorToError(cleanupError));
                     });
                 } else {
-                    unzipPackage();
+                    unzipAndVerifyPackage();
                 }
             });
         } catch (e) {
             installError && installError(new Error("An error occured while installing the package. " + CodePushUtil.getErrorMessage(e)));
         }
+    }
+
+    private verifyPackage(unzipDir: DirectoryEntry, installError: ErrorCallback, callback: Callback<boolean>): void {
+        var packageHashSuccess = (localHash: string) => {
+            FileUtil.readFile(cordova.file.dataDirectory, unzipDir.fullPath + '/www', '.codepushrelease', (error, contents) => {
+                var verifySignatureSuccess = (expectedHash?: string) => {
+                    // first, we always compare the hash we just calculated to the packageHash reported from the server
+                    if (localHash !== this.packageHash) {
+                        installError(new Error("package hash verification failed"));
+                        return;
+                    }
+
+                    // this happens if (and only if) no public key is available in config.xml
+                    // -> no code signing
+                    if (!expectedHash) {
+                        callback(null, false);
+                        return;
+                    }
+
+                    // code signing is active, only proceed if the locally computed hash is the same as the one decoded from the JWT
+                    if (localHash === expectedHash) {
+                        callback(null, true);
+                        return;
+                    }
+
+                    installError(new Error("package hash verification failed"));
+                };
+                var verifySignatureFail = (error: string) => {
+                    installError && installError(new Error("signature verification error: " + error));
+                };
+                cordova.exec(verifySignatureSuccess, verifySignatureFail, "CodePush", "verifySignature", [contents]);
+            });
+        };
+        var packageHashFail = (error: string) => {
+            installError && installError(new Error("unable to compute hash for package: " + error));
+        };
+        cordova.exec(packageHashSuccess, packageHashFail,"CodePush","getPackageHash",[unzipDir.fullPath]);
     }
 
     private finishInstall(deployDir: DirectoryEntry, installOptions: InstallOptions, installSuccess: SuccessCallback<InstallMode>, installError: ErrorCallback): void {


### PR DESCRIPTION
This patch implements checking of the `packageHash` of downloaded updates for Android and iOS and implements code signing for iOS. 