### PR TITLE
Code signing implemented for Android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -60,6 +60,7 @@
         <platform name="android">
             <framework src="src/android/build-extras.gradle" custom="true" type="gradleReference" />
             <source-file src="src/android/CodePush.java" target-dir="src/com/microsoft/cordova" />
+            <source-file src="src/android/CodePushException.java" target-dir="src/com/microsoft/cordova" />
             <source-file src="src/android/CodePushPackageManager.java" target-dir="src/com/microsoft/cordova" />
             <source-file src="src/android/CodePushPackageMetadata.java" target-dir="src/com/microsoft/cordova" />
             <source-file src="src/android/CodePushPreferences.java" target-dir="src/com/microsoft/cordova" />

--- a/src/android/CodePush.java
+++ b/src/android/CodePush.java
@@ -2,6 +2,10 @@ package com.microsoft.cordova;
 
 import android.content.pm.PackageManager;
 import android.os.AsyncTask;
+import android.util.Base64;
+
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.JWTVerifyException;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.ConfigXmlParser;
@@ -14,9 +18,16 @@ import org.json.JSONException;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.security.InvalidKeyException;
+import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.SignatureException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
 
 import java.util.Date;
+import java.util.Map;
 
 /**
  * Native Android CodePush Cordova Plugin.
@@ -24,6 +35,8 @@ import java.util.Date;
 public class CodePush extends CordovaPlugin {
 
     private static final String DEPLOYMENT_KEY_PREFERENCE = "codepushdeploymentkey";
+    private static final String PUBLIC_KEY_PREFERENCE = "codepushpublickey";
+    private static final String SERVER_URL_PREFERENCE = "codepushserverurl";
     private static final String WWW_ASSET_PATH_PREFIX = "file:///android_asset/www/";
     private static boolean ShouldClearHistoryOnLoad = false;
     private CordovaWebView mainWebView;
@@ -56,7 +69,7 @@ public class CodePush extends CordovaPlugin {
         } else if ("getNativeBuildTime".equals(action)) {
             return execGetNativeBuildTime(callbackContext);
         } else if ("getServerURL".equals(action)) {
-            this.returnStringPreference("codepushserverurl", callbackContext);
+            this.returnStringPreference(SERVER_URL_PREFERENCE, callbackContext);
             return true;
         } else if ("install".equals(action)) {
             return execInstall(args, callbackContext);
@@ -89,12 +102,91 @@ public class CodePush extends CordovaPlugin {
         new AsyncTask<Void, Void, Void>() {
             @Override
             protected Void doInBackground(Void... voids) {
-                // no actual code sign verification implemented for Android yet, just return null
-                callbackContext.success((String) null);
+                String stringPublicKey = mainWebView.getPreferences().getString(PUBLIC_KEY_PREFERENCE, null);
+
+                // bail out early if no public key was configured in config.xml
+                if (stringPublicKey == null) {
+                    callbackContext.success((String) null);
+                    return null;
+                }
+
+                final PublicKey publicKey;
+                try {
+                    publicKey = parsePublicKey(stringPublicKey);
+                } catch (CodePushException e) {
+                    callbackContext.error("Error occured while creating the a public key" + e.getMessage());
+                    return null;
+                }
+
+
+                final String signature = getSignature(args);
+                if (signature == null) {
+                    callbackContext.error("The update could not be verified because no signature was found.");
+                    return null;
+                }
+
+
+                final Map<String, Object> claims;
+                try {
+                    claims = verifyAndDecodeJWT(signature, publicKey);
+                } catch (CodePushException e) {
+                    callbackContext.error("The update could not be verified because it was not signed by a trusted party. " + e.getMessage());
+                    return null;
+                }
+
+                final String contentHash = (String) claims.get("contentHash");
+                if (contentHash == null) {
+                    callbackContext.error("The update could not be verified because the signature did not specify a content hash.");
+                    return null;
+                }
+
+                callbackContext.success(contentHash);
                 return null;
             }
         }.execute();
         return true;
+    }
+
+    private PublicKey parsePublicKey(String stringPublicKey) throws CodePushException {
+        try {
+            byte[] byteKey = Base64.decode(stringPublicKey.getBytes(), Base64.DEFAULT);
+            X509EncodedKeySpec X509Key = new X509EncodedKeySpec(byteKey);
+            KeyFactory kf = KeyFactory.getInstance("RSA");
+            return kf.generatePublic(X509Key);
+        } catch (InvalidKeySpecException e) {
+            throw new CodePushException(e);
+        } catch (NoSuchAlgorithmException e) {
+            throw new CodePushException(e);
+        }
+    }
+
+    private Map<String, Object> verifyAndDecodeJWT(String jwt, PublicKey publicKey) throws CodePushException {
+        try {
+            final JWTVerifier verifier = new JWTVerifier(publicKey);
+            return verifier.verify(jwt);
+        } catch (NoSuchAlgorithmException e) {
+            throw new CodePushException(e);
+        } catch (InvalidKeyException e) {
+            throw new CodePushException(e);
+        } catch (IOException e) {
+            throw new CodePushException(e);
+        } catch (SignatureException e) {
+            throw new CodePushException(e);
+        } catch (JWTVerifyException e) {
+            throw new CodePushException(e);
+        }
+    }
+
+    private String getSignature(CordovaArgs args) {
+        try {
+            if (args.isNull(0)) {
+                return null;
+            } else {
+                return args.getString(0);
+            }
+        } catch (JSONException e) {
+            return null;
+        }
     }
 
     private boolean execGetBinaryHash(final CallbackContext callbackContext) {

--- a/src/android/CodePushException.java
+++ b/src/android/CodePushException.java
@@ -1,0 +1,26 @@
+package com.microsoft.cordova;
+
+/**
+ * Created by kgoranchev on 19/10/2017.
+ */
+
+public class CodePushException extends Exception {
+    public CodePushException() {
+    }
+
+    public CodePushException(String message) {
+        super(message);
+    }
+
+    public CodePushException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CodePushException(Throwable cause) {
+        super(cause);
+    }
+
+    public CodePushException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/android/CodePushException.java
+++ b/src/android/CodePushException.java
@@ -1,9 +1,5 @@
 package com.microsoft.cordova;
 
-/**
- * Created by kgoranchev on 19/10/2017.
- */
-
 public class CodePushException extends Exception {
     public CodePushException() {
     }
@@ -18,9 +14,5 @@ public class CodePushException extends Exception {
 
     public CodePushException(Throwable cause) {
         super(cause);
-    }
-
-    public CodePushException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-        super(message, cause, enableSuppression, writableStackTrace);
     }
 }

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -54,3 +54,7 @@ android.buildTypes.each {
    // https://github.com/Microsoft/cordova-plugin-code-push/issues/264
    it.resValue "string", "CODE_PUSH_APK_BUILD_TIME", String.format("\"%d\"", System.currentTimeMillis())
 }
+
+dependencies {
+    compile 'com.auth0:java-jwt:2.2.2'
+}

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -56,5 +56,5 @@ android.buildTypes.each {
 }
 
 dependencies {
-    compile 'com.auth0:java-jwt:2.2.2'
+    compile 'com.nimbusds:nimbus-jose-jwt:5.1'
 }


### PR DESCRIPTION
Code signing implemented for Android. As a reference implementation was taken the react native implementation. The requirement is to have public key in the `config.xml` with a key `CodePushPublicKey`. That same as the ios implementation of code signing. 