### PR TITLE
Fixed binary hash calculation on android.

### DIFF
--- a/src/android/CodePush.java
+++ b/src/android/CodePush.java
@@ -111,6 +111,8 @@ public class CodePush extends CordovaPlugin {
                         callbackContext.error("An error occurred when trying to get the hash of the binary contents. " + e.getMessage());
                     } catch (NoSuchAlgorithmException e) {
                         callbackContext.error("An error occurred when trying to get the hash of the binary contents. " + e.getMessage());
+                    } catch (ClassNotFoundException e) {
+                        callbackContext.error("An error occurred when trying to get the hash of the binary contents. " + e.getMessage());
                     }
 
                     return null;
@@ -135,6 +137,8 @@ public class CodePush extends CordovaPlugin {
                 } catch (NoSuchAlgorithmException e) {
                     callbackContext.error("An error occurred when trying to get the hash of the binary contents. " + e.getMessage());
                 } catch (JSONException e) {
+                    callbackContext.error("An error occurred when trying to get the hash of the binary contents. " + e.getMessage());
+                } catch (ClassNotFoundException e) {
                     callbackContext.error("An error occurred when trying to get the hash of the binary contents. " + e.getMessage());
                 }
 

--- a/src/android/Utilities.java
+++ b/src/android/Utilities.java
@@ -3,6 +3,7 @@ package com.microsoft.cordova;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.content.res.AssetManager;
 import android.content.res.Resources;
 import android.util.Log;
 
@@ -10,6 +11,11 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static java.lang.Long.parseLong;
 
@@ -73,5 +79,43 @@ public class Utilities {
 
     public static void logException(Throwable e) {
         Log.e(CodePush.class.getName(), "An error occured. " + e.getMessage(), e);
+    }
+
+
+    /**
+     * Getting the full path to all the assets in a given asset path.
+     * Note: implementation is cased on cdvasset.manifest which is generated during build time
+     * @param assetManager a reference to the android's asset manager
+     * @param path the asset path for which we want the asset list, if null is passed it will take all the asset from the root
+     * @param ignoredFiles the files to be ignored when generating the list, if null is passed it will not ignore any files
+     * @return list of paths to all the assets for a given path in the following format: path/to/asset/asset_name.xxx
+     */
+    public static String[] getAssetsList(AssetManager assetManager, String path, Set<String> ignoredFiles) throws IOException, ClassNotFoundException {
+        ObjectInputStream ois = null;
+        List<String> flatAssetPaths = new ArrayList<String>();
+        try {
+            ois = new ObjectInputStream(assetManager.open("cdvasset.manifest"));
+            Map<String, String[]> directoryList = (Map<String, String[]>) ois.readObject();
+
+            for(String directoryKey: directoryList.keySet()){
+                if(!directoryKey.startsWith(path)){
+                    continue; //skip all the assets that are not in the path
+                }
+                String[] directoryContent = directoryList.get(directoryKey);
+                for(String item : directoryContent){
+                    String absolutePath = directoryKey + "/" + item;
+                    // check if the item is an asset, if it is not an asset it should be present as a key in the directory list
+                    if(!directoryList.containsKey(absolutePath) && ( ignoredFiles == null || !ignoredFiles.contains(item))) {
+                        flatAssetPaths.add(absolutePath);
+                    }
+                }
+            }
+
+            return flatAssetPaths.toArray(new String[]{});
+        } finally {
+            if (ois != null) {
+                ois.close();
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR is a proposal that fixes #303.

### The Solution
Since I couldn't find a easy and clean solution to determine if a the asset is a directory or not, I had a look how the `cordova-plugin-file` is solving this problem and according to the documentation recursion is not a good idea in the asset folder anyway: http://cordova.apache.org/docs/en/7.x/reference/cordova-plugin-file/index.html#slow-recursive-operations-for-android_asset.

My idea is to use the `cdvasset.manifest`, which we generate anyway during the build, to get a flat list containing the path to all the  asset within the `www` folder, which is later used for hash calculation.

The drawback is that we create a dependency to the `cdvCreateAssetManifest` build task, which should be clearly stated in case you accept my solution.