### PR TITLE
Fix TypeError when calling logError without error.

### DIFF
--- a/bin/www/codePushUtil.js
+++ b/bin/www/codePushUtil.js
@@ -36,7 +36,7 @@ var CodePushUtil = (function () {
     };
     CodePushUtil.logError = function (message, error) {
         var errorMessage = (message || "") + " " + CodePushUtil.getErrorMessage(error);
-        var stackTrace = error.stack ? ". StackTrace: " + error.stack : '';
+        var stackTrace = error && error.stack ? ". StackTrace: " + error.stack : '';
         console.error(CodePushUtil.TAG + " " + errorMessage + stackTrace);
     };
     CodePushUtil.TAG = "[CodePush]";

--- a/www/codePushUtil.ts
+++ b/www/codePushUtil.ts
@@ -66,7 +66,7 @@ class CodePushUtil {
      */
     public static logError(message: String, error?: Error): void {
         const errorMessage = `${message || ""} ${CodePushUtil.getErrorMessage(error)}`;
-        const stackTrace = error.stack ? `. StackTrace: ${error.stack}` : '';
+        const stackTrace = error && error.stack ? `. StackTrace: ${error.stack}` : '';
         console.error(`${CodePushUtil.TAG} ${errorMessage}${stackTrace}`);
     }
 }


### PR DESCRIPTION
"Error in Error callbackId: TypeError: Cannot read property 'stack' of undefined"

The error (above) occurs when calling codePush.sync() when there are no existing downloaded updates. This patch fixes the bug.