### PR TITLE
add cordova-plugin-zip as dependency

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -9,6 +9,7 @@
         <dependency id="code-push" version="2.0.5" />
         <dependency id="cordova-plugin-dialogs" version=">=1.1.1" />
         <dependency id="cordova-plugin-device" version=">=1.1.0" />
+        <dependency id="cordova-plugin-zip" version="3.1.0" />
 
         <hook type="after_plugin_add" src="hooks/afterPluginAdd.js" />
 


### PR DESCRIPTION
Since cordova-plugin-zip is used within the plugin and also installed via the hooks, to maintain consistency & clarity add cordova-plugin-zip as dependency in plugin.xml