### PR TITLE
Added cordova-plugin-ionic-webview 2+ support for Android and iOS

### DIFF
--- a/src/android/CodePush.java
+++ b/src/android/CodePush.java
@@ -638,18 +638,17 @@ public class CodePush extends CordovaPlugin {
         return false;
     }
 
-    private void setServerBasePath(String serverPath) {
+    private void setServerBasePath(final String serverPath) {
         try {
           Class ionicWebViewEngineClass = Class.forName("com.ionicframework.cordova.webview.IonicWebViewEngine");
           Object ionicWebViewEngine = ionicWebViewEngineClass.cast(this.mainWebView.getEngine());
           Method setServerBasePath = ionicWebViewEngineClass.getMethod("setServerBasePath", String.class);
 
-          final String ionicWebViewEngineServerPath = serverPath;
           this.cordova.getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
               try {
-                setServerBasePath.invoke(ionicWebViewEngine, ionicWebViewEngineServerPath);
+                setServerBasePath.invoke(ionicWebViewEngine, serverPath);
               } catch (IllegalAccessException | InvocationTargetException e) {
                 Utilities.logException(e);
               }

--- a/src/android/CodePush.java
+++ b/src/android/CodePush.java
@@ -527,9 +527,8 @@ public class CodePush extends CordovaPlugin {
                     String ionicWebViewEngineUrlPath = new URI(url).getPath();
                     String ionicWebViewEngineServerPath = ionicWebViewEngineUrlPath.substring(0, ionicWebViewEngineUrlPath.indexOf("/index.html"));
                     this.setServerBasePath(ionicWebViewEngineServerPath);
-                    return;
                 } catch (URISyntaxException e) {
-                    e.printStackTrace();
+                    Utilities.logException(e);
                 }
             } else {
                 this.mainWebView.loadUrlIntoView(url, false);
@@ -652,15 +651,14 @@ public class CodePush extends CordovaPlugin {
               try {
                 setServerBasePath.invoke(ionicWebViewEngine, ionicWebViewEngineServerPath);
               } catch (IllegalAccessException | InvocationTargetException e) {
-                e.printStackTrace();
+                Utilities.logException(e);
               }
             }
           });
-          return;
         } catch (ClassNotFoundException | NoSuchMethodException e) {
-          e.printStackTrace();
+          Utilities.logException(e);
         }
-  }
+    }
 
     /**
      * The final call you receive before your activity is destroyed.


### PR DESCRIPTION
- Check whether cordova-plugin-ionic-webview 2+ is installed on Android by looking for com.ionicframework.cordova.webview.IonicWebViewEngine class. If so, it calls IonicWebViewEngine.setServerBasePath instead of navigating to file via this.mainWebView.loadUrlIntoView(url, false);

- Check whether cordova-plugin-ionic-webview 2+ is installed on iOS by looking for setServerBasePath selector in webViewEngine. If so, splits NSUrl path components, removes last one, joins again and passes to webViewEngine as part of CDVInvokedUrlCommand.