### PR TITLE
Fix Ionic requests(white screen)

### DIFF
--- a/src/ios/CDVWKWebViewEngine+CodePush.m
+++ b/src/ios/CDVWKWebViewEngine+CodePush.m
@@ -11,12 +11,12 @@
 
 - (id)loadRequest:(NSURLRequest *)request {
     NSURL *readAccessURL;
-    
+
     if (request.URL.isFileURL) {
-        // All file URL requests should be handled with setServerBasePath in case if It is Ionic app.
+        // All file URL requests should be handled with the setServerBasePath in case if it is Ionic app.
         if ([CodePush hasIonicWebViewEngine: self]) {
             [CodePush setServerBasePath:request.URL.path webView: self];
-                
+
             return nil;
         }
 
@@ -33,7 +33,7 @@
             // If we didn't set this, then the attempt to navigate from the bundle to a CodePush update would fail.
             readAccessURL = [[[NSBundle mainBundle] bundleURL] URLByDeletingLastPathComponent];
         }
-        
+
         return [(WKWebView*)self.engineWebView loadFileURL:request.URL allowingReadAccessToURL:readAccessURL];
     } else {
         return [(WKWebView*)self.engineWebView loadRequest: request];

--- a/src/ios/CDVWKWebViewEngine+CodePush.m
+++ b/src/ios/CDVWKWebViewEngine+CodePush.m
@@ -13,18 +13,19 @@
     NSURL *readAccessURL;
     
     if (request.URL.isFileURL) {
-        if ([request.URL.absoluteString containsString:@"codepush"]) {
-            if ([CodePush hasIonicWebViewEngine: self]) {
-                [CodePush setServerBasePath:request.URL.path webView: self];
+        // All file URL requests should be handled with setServerBasePath in case if It is Ionic app.
+        if ([CodePush hasIonicWebViewEngine: self]) {
+            [CodePush setServerBasePath:request.URL.path webView: self];
                 
-                return nil;
-            } else {
-                // If the app is attempting to load a CodePush update, then we can lock the WebView down to
-                // just the CodePush "versions" directory. This prevents non-CodePush assets from being accessible,
-                // while still allowing us to navigate to a future update, as well as to the binary if a rollback is needed.
-                NSString *libraryPath = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES)[0];
-                readAccessURL = [NSURL fileURLWithPathComponents:@[libraryPath, @"NoCloud", @"codepush", @"deploy", @"versions"]];
-            }
+            return nil;
+        }
+
+        if ([request.URL.absoluteString containsString:@"codepush"]) {
+            // If the app is attempting to load a CodePush update, then we can lock the WebView down to
+            // just the CodePush "versions" directory. This prevents non-CodePush assets from being accessible,
+            // while still allowing us to navigate to a future update, as well as to the binary if a rollback is needed.
+            NSString *libraryPath = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES)[0];
+            readAccessURL = [NSURL fileURLWithPathComponents:@[libraryPath, @"NoCloud", @"codepush", @"deploy", @"versions"]];
         } else {
             // In order to allow the WebView to be navigated from the app bundle to another location, we (for some
             // entirely unknown reason) need to ensure that the "read access URL" is set to the parent of the bundle


### PR DESCRIPTION
**Issue:** Ionic app should call all file URL requests with `setServerBasePath` method otherwise app shows just white screen.

**Solution:** Replaced calling `setServerBasePath` method to using it with all URL request.

Related issue: https://github.com/Microsoft/cordova-plugin-code-push/issues/486