### PR TITLE
use cdvPluginPostBuildExtras instead

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -19,7 +19,7 @@
        specific language governing permissions and limitations
        under the License.
  */
-ext.postBuildExtras = {
+cdvPluginPostBuildExtras.add({
     
     def inAssetsDir = file("src/main/assets")
     if (!inAssetsDir.exists()) { // Add support for cordova-android < 7.0.0
@@ -52,7 +52,7 @@ ext.postBuildExtras = {
     newTask.outputs.file outFile
     def preBuildTask = tasks["preBuild"]
     preBuildTask.dependsOn(newTask)
-}
+})
 
 android.buildTypes.each {
    // to prevent incorrect long value restoration from strings.xml we need to wrap it with double quotes


### PR DESCRIPTION
- Use cdvPluginPostBuildExtras instead of postBuildExtras to avoid conflict with other plugins.