### PR TITLE
replace hardcoded index.html string with config defined content src

### DIFF
--- a/src/android/CodePush.java
+++ b/src/android/CodePush.java
@@ -525,7 +525,7 @@ public class CodePush extends CordovaPlugin {
             if (this.hasIonicWebViewEngine()) {
                 try {
                     String ionicWebViewEngineUrlPath = new URI(url).getPath();
-                    String ionicWebViewEngineServerPath = ionicWebViewEngineUrlPath.substring(0, ionicWebViewEngineUrlPath.indexOf("/index.html"));
+                    String ionicWebViewEngineServerPath = ionicWebViewEngineUrlPath.substring(0, ionicWebViewEngineUrlPath.indexOf("/" + getConfigStartPageName()));
                     this.setServerBasePath(ionicWebViewEngineServerPath);
                 } catch (URISyntaxException e) {
                     Utilities.logException(e);


### PR DESCRIPTION
**Issue**: inside cordova config.xml if `<content src="index.html" />` is not index.html, after codepush update app will crash with StringIndexOutOfBoundsException

**Solution**: change hardcoded index.html to ConfigStartPageName