### PR TITLE
Replace leftShift with 'doLast' for cdvCreateAssetManifest in build-extras.gradle file

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -29,23 +29,25 @@ ext.postBuildExtras = {
     def outAssetsDir = inAssetsDir
     def outFile = new File(outAssetsDir, "cdvasset.manifest")
 
-    def newTask = task("cdvCreateAssetManifest") << {
-        def contents = new HashMap()
-        def sizes = new HashMap()
-        contents[""] = inAssetsDir.list()
-        def tree = fileTree(dir: inAssetsDir)
-        tree.visit { fileDetails ->
-            if (fileDetails.isDirectory()) {
-                contents[fileDetails.relativePath.toString()] = fileDetails.file.list()
-            } else {
-                sizes[fileDetails.relativePath.toString()] = fileDetails.file.length()
+    def newTask = task("cdvCreateAssetManifest") {
+        doLast {
+            def contents = new HashMap()
+            def sizes = new HashMap()
+            contents[""] = inAssetsDir.list()
+            def tree = fileTree(dir: inAssetsDir)
+            tree.visit { fileDetails ->
+                if (fileDetails.isDirectory()) {
+                    contents[fileDetails.relativePath.toString()] = fileDetails.file.list()
+                } else {
+                    sizes[fileDetails.relativePath.toString()] = fileDetails.file.length()
+                }
             }
-        }
 
-        outAssetsDir.mkdirs()
-        outFile.withObjectOutputStream { oos ->
-            oos.writeObject(contents)
-            oos.writeObject(sizes)
+            outAssetsDir.mkdirs()
+            outFile.withObjectOutputStream { oos ->
+                oos.writeObject(contents)
+                oos.writeObject(sizes)
+            }
         }
     }
     newTask.inputs.dir inAssetsDir


### PR DESCRIPTION
Replacing deprecated leftShift operator with `doLast` for cdvCreateAssetManifest task in build-extras.gradle file

Related issue https://github.com/Microsoft/cordova-plugin-code-push/issues/512