### PR TITLE
Include "types" in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   ],
   "author": "Microsoft Corporation",
   "license": "MIT",
+  "types": "./typings/codePush.d.ts",
   "devDependencies": {
     "@types/assert": "0.0.31",
     "@types/cordova": "0.0.34",


### PR DESCRIPTION
This change will enable the use of the types of this package.

``` 
/// <reference types="cordova-plugin-code-push" />
```