### PR TITLE
Fix webView inability to load codepush start page after terminating

### DIFF
--- a/src/ios/CDVWKWebViewEngine+CodePush.m
+++ b/src/ios/CDVWKWebViewEngine+CodePush.m
@@ -7,11 +7,13 @@
 @implementation CDVWKWebViewEngine (CodePush)
 
 NSString* const IdentifierCodePushPath = @"codepush/deploy/versions";
+NSString* lastLoadedURL = @"";
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wobjc-protocol-method-implementation"
 
 - (id)loadRequest:(NSURLRequest *)request {
+    lastLoadedURL = request.URL.absoluteString;
     NSURL *readAccessURL;
 
     if (request.URL.isFileURL) {
@@ -50,14 +52,13 @@ NSString* const IdentifierCodePushPath = @"codepush/deploy/versions";
 // Fix bug related to unable WKWebView recovery after reinit with loaded codepush update
 - (void)webView:(WKWebView*)theWebView didFailNavigation:(WKNavigation*)navigation withError:(NSError*)error
 {
-    CDVViewController* vc = (CDVViewController*)self.viewController;
     // NSURLErrorFailingURLStringErrorKey is URL which caused a load to fail, if it's null then webView was terminated for some reason
-    if ([[error userInfo] objectForKey:NSURLErrorFailingURLStringErrorKey] == nil && [[vc startPage] containsString:IdentifierCodePushPath])
+    if ([[error userInfo] objectForKey:NSURLErrorFailingURLStringErrorKey] == nil && [lastLoadedURL containsString:IdentifierCodePushPath])
     {
         NSLog(@"Failed to load webpage with error: %@", [error localizedDescription]);
-        NSLog(@"Trying to reload request with url: %@", [vc startPage]);
+        NSLog(@"Trying to reload request with url: %@", lastLoadedURL);
         // Manually loading codepush start page via loadRequest method of this category
-        [self loadRequest: [NSURLRequest requestWithURL:[[NSURL alloc] initWithString:[vc startPage]]]];
+        [self loadRequest: [NSURLRequest requestWithURL:[[NSURL alloc] initWithString:lastLoadedURL]]];
     } else {
         // Default implementation of didFailNavigation method of CDVWKWebViewEngine.m
         CDVViewController* vc = (CDVViewController*)self.viewController;

--- a/src/ios/CDVWKWebViewEngine+CodePush.m
+++ b/src/ios/CDVWKWebViewEngine+CodePush.m
@@ -51,10 +51,13 @@ BOOL navigationFailedFlag = false;
 - (void)webView:(WKWebView*)theWebView didFailNavigation:(WKNavigation*)navigation withError:(NSError*)error
 {
     CDVViewController* vc = (CDVViewController*)self.viewController;
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(resetNavigationFailedFlag:) name:CDVPageDidLoadNotification object:nil];
     // Humble check for preventing infinity loop with navigation error handlers
     if (!navigationFailedFlag) {
+        navigationFailedFlag = true;
         [self loadRequest: [NSURLRequest requestWithURL:[[NSURL alloc] initWithString:[vc startPage]]]];
     } else {
+        [self resetNavigationFailedFlag:nil];
         NSString* message = [NSString stringWithFormat:@"Failed to load webpage with error: %@", [error localizedDescription]];
         NSLog(@"%@", message);
         [CDVUserAgentUtil releaseLock:vc.userAgentLockToken];
@@ -65,7 +68,12 @@ BOOL navigationFailedFlag = false;
             [theWebView loadRequest:[NSURLRequest requestWithURL:errorUrl]];
         }
     }
-    navigationFailedFlag =true;
+}
+
+- (void)resetNavigationFailedFlag:(NSNotification*)notification
+{
+    navigationFailedFlag = false;
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:CDVPageDidLoadNotification object:nil];
 }
 
 @end

--- a/src/ios/CDVWKWebViewEngine+CodePush.m
+++ b/src/ios/CDVWKWebViewEngine+CodePush.m
@@ -47,17 +47,19 @@ NSString* const IdentifierCodePushPath = @"codepush/deploy/versions";
 
 #pragma clang diagnostic pop
 
+// Fix bug related to unable WKWebView recovery after reinit with loaded codepush update
 - (void)webView:(WKWebView*)theWebView didFailNavigation:(WKNavigation*)navigation withError:(NSError*)error
 {
     CDVViewController* vc = (CDVViewController*)self.viewController;
-    // With null NSURLErrorFailingURLStringErrorKey navigation failed because of the webView terminating
+    // NSURLErrorFailingURLStringErrorKey is URL which caused a load to fail, if it's null then webView was terminated for some reason
     if ([[error userInfo] objectForKey:NSURLErrorFailingURLStringErrorKey] == nil && [[vc startPage] containsString:IdentifierCodePushPath])
     {
         NSLog(@"Failed to load webpage with error: %@", [error localizedDescription]);
-        NSLog(@"Trying reload request with url: %@", [vc startPage]);
+        NSLog(@"Trying to reload request with url: %@", [vc startPage]);
+        // Manually loading codepush start page via loadRequest method of this category
         [self loadRequest: [NSURLRequest requestWithURL:[[NSURL alloc] initWithString:[vc startPage]]]];
     } else {
-        // default functionality of didFailNavigation
+        // Default implementation of didFailNavigation method of CDVWKWebViewEngine.m
         CDVViewController* vc = (CDVViewController*)self.viewController;
         NSString* message = [NSString stringWithFormat:@"Failed to load webpage with error: %@", [error localizedDescription]];
         NSLog(@"%@", message);

--- a/src/ios/CDVWKWebViewEngine+CodePush.m
+++ b/src/ios/CDVWKWebViewEngine+CodePush.m
@@ -50,11 +50,9 @@ NSString* lastLoadedURL = @"";
 #pragma clang diagnostic pop
 
 // Fix bug related to unable WKWebView recovery after reinit with loaded codepush update
-- (void)webView:(WKWebView*)theWebView didFailNavigation:(WKNavigation*)navigation withError:(NSError*)error
-{
+- (void)webView:(WKWebView*)theWebView didFailNavigation:(WKNavigation*)navigation withError:(NSError*)error {
     // NSURLErrorFailingURLStringErrorKey is URL which caused a load to fail, if it's null then webView was terminated for some reason
-    if ([[error userInfo] objectForKey:NSURLErrorFailingURLStringErrorKey] == nil && [lastLoadedURL containsString:IdentifierCodePushPath])
-    {
+    if ([[error userInfo] objectForKey:NSURLErrorFailingURLStringErrorKey] == nil && [lastLoadedURL containsString:IdentifierCodePushPath]) {
         NSLog(@"Failed to load webpage with error: %@", [error localizedDescription]);
         NSLog(@"Trying to reload request with url: %@", lastLoadedURL);
         // Manually loading codepush start page via loadRequest method of this category


### PR DESCRIPTION
**Issue**: WKWebView can't load codepush start page after terminating webView process.

**Error**: `Failed to load webpage with error: The operation couldn’t be completed. (kCFErrorDomainCFNetwork error 1.)`

**Solution**: Override `didFailNavigation` method of CDVWKWebViewEngine in the `CDVWKWebViewEngine+CodePush.m` file. This method is executed after unsuccessful loading URL by WKWebView. In case if WebView was terminated and start page of viewController reference to codepush update then start page will be directly loaded repeatedly. Otherwise default implementation of `didFailNavigation` will be executed.

Related issue https://github.com/microsoft/cordova-plugin-code-push/issues/529