### PR TITLE
Update the build-extras.gradle file

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -19,7 +19,7 @@
        specific language governing permissions and limitations
        under the License.
  */
-ext.postBuildExtras = {
+cdvPluginPostBuildExtras.add({
     
     def inAssetsDir = file("src/main/assets")
     if (!inAssetsDir.exists()) { // Add support for cordova-android < 7.0.0
@@ -54,7 +54,7 @@ ext.postBuildExtras = {
     newTask.outputs.file outFile
     def preBuildTask = tasks["preBuild"]
     preBuildTask.dependsOn(newTask)
-}
+})
 
 android.buildTypes.each {
    // to prevent incorrect long value restoration from strings.xml we need to wrap it with double quotes


### PR DESCRIPTION
Cordova Jira Ticket Exapling the Bug this fixes
https://issues.apache.org/jira/browse/CB-14163

We had trouble using this plugin on android with other plugins that also try to use ext.postBuildExtras.
We had cordova-support-google-services and cordova-plugin-code-push installed as well as this plugin and all three were trying to use postBuildExtras.
But only the last plugin listed in our config file would have its code executed at built time. the link above describes the cause of the issue pretty well