### PR TITLE
fix(load): load different application path

### DIFF
--- a/src/android/CodePush.java
+++ b/src/android/CodePush.java
@@ -420,7 +420,7 @@ public class CodePush extends CordovaPlugin {
         CodePushPackageMetadata deployedPackageMetadata = this.codePushPackageManager.getCurrentPackageMetadata();
         if (deployedPackageMetadata != null && deployedPackageMetadata.localPath != null) {
             File startPage = this.getStartPageForPackage(deployedPackageMetadata.localPath);
-            if (startPage != null) {
+            if (startPage != null && this.isMainBundleActivity()) {
                 /* file exists */
                 try {
                     navigateToFile(startPage);
@@ -429,6 +429,12 @@ public class CodePush extends CordovaPlugin {
                 }
             }
         }
+    }
+
+    private boolean isMainBundleActivity() {
+        final String activityPackage = this.cordova.getActivity().getClass().getPackage().getName();
+        final String contextPackage = this.cordova.getContext().getPackageName();
+        return contextPackage.contains(activityPackage);
     }
 
     private boolean execPreInstall(CordovaArgs args, CallbackContext callbackContext) {

--- a/src/ios/CDVWKWebViewEngine+CodePush.m
+++ b/src/ios/CDVWKWebViewEngine+CodePush.m
@@ -1,6 +1,7 @@
 #if defined(__has_include)
 #if __has_include("CDVWKWebViewEngine.h")
 
+#import <Cordova/NSDictionary+CordovaPreferences.h>
 #import "CDVWKWebViewEngine.h"
 #import "CodePush.h"
 
@@ -15,6 +16,10 @@ NSString* lastLoadedURL = @"";
 - (id)loadRequest:(NSURLRequest *)request {
     lastLoadedURL = request.URL.absoluteString;
     NSURL *readAccessURL;
+
+    if (![lastLoadedURL containsString:@".app"]) {
+        return [self loadPluginRequest:request];
+    }
 
     if (request.URL.isFileURL) {
         // All file URL requests should be handled with the setServerBasePath in case if it is Ionic app.
@@ -45,6 +50,36 @@ NSString* lastLoadedURL = @"";
     } else {
         return [(WKWebView*)self.engineWebView loadRequest: request];
     }
+}
+
+- (id)loadPluginRequest:(NSURLRequest *)request {
+    if (request.URL.fileURL) {
+        NSDictionary* settings = self.commandDelegate.settings;
+        NSString *bind = [settings cordovaSettingForKey:@"Hostname"];
+        if(bind == nil){
+            bind = @"localhost";
+        }
+        NSString *scheme = [settings cordovaSettingForKey:@"iosScheme"];
+        if(scheme == nil || [scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"]  || [scheme isEqualToString:@"file"]){
+            scheme = @"ionic";
+        }
+        NSString *CDV_LOCAL_SERVER = [NSString stringWithFormat:@"%@://%@", scheme, bind];
+        
+        NSURL* startURL = [NSURL URLWithString:((CDVViewController *)self.viewController).startPage];
+        NSString* startFilePath = [self.commandDelegate pathForResource:[startURL path]];
+        NSURL *url = [[NSURL URLWithString:CDV_LOCAL_SERVER] URLByAppendingPathComponent:request.URL.path];
+        if ([request.URL.path isEqualToString:startFilePath]) {
+            url = [NSURL URLWithString:CDV_LOCAL_SERVER];
+        }
+        if(request.URL.query) {
+            url = [NSURL URLWithString:[@"?" stringByAppendingString:request.URL.query] relativeToURL:url];
+        }
+        if(request.URL.fragment) {
+            url = [NSURL URLWithString:[@"#" stringByAppendingString:request.URL.fragment] relativeToURL:url];
+        }
+        request = [NSURLRequest requestWithURL:url];
+    }
+    return [(WKWebView*)self.engineWebView loadRequest:request];
 }
 
 #pragma clang diagnostic pop

--- a/src/ios/CDVWKWebViewEngine+CodePush.m
+++ b/src/ios/CDVWKWebViewEngine+CodePush.m
@@ -17,7 +17,8 @@ NSString* lastLoadedURL = @"";
     lastLoadedURL = request.URL.absoluteString;
     NSURL *readAccessURL;
 
-    if (![lastLoadedURL containsString:@".app"] && ![lastLoadedURL containsString:@"codepush"]) {
+    NSURL* bundleURL = [[NSBundle mainBundle] bundleURL];
+    if (![lastLoadedURL containsString:bundleURL.path] && ![lastLoadedURL containsString:IdentifierCodePushPath]) {
         return [self loadPluginRequest:request];
     }
 

--- a/src/ios/CDVWKWebViewEngine+CodePush.m
+++ b/src/ios/CDVWKWebViewEngine+CodePush.m
@@ -17,7 +17,7 @@ NSString* lastLoadedURL = @"";
     lastLoadedURL = request.URL.absoluteString;
     NSURL *readAccessURL;
 
-    if (![lastLoadedURL containsString:@".app"]) {
+    if (![lastLoadedURL containsString:@".app"] && ![lastLoadedURL containsString:@"codepush"]) {
         return [self loadPluginRequest:request];
     }
 

--- a/src/ios/CodePush.m
+++ b/src/ios/CodePush.m
@@ -341,6 +341,11 @@ StatusReport* rollbackStatusReport = nil;
 - (void)navigateToLocalDeploymentIfExists {
     CodePushPackageMetadata* deployedPackageMetadata = [CodePushPackageManager getCurrentPackageMetadata];
     if (deployedPackageMetadata && deployedPackageMetadata.localPath) {
+        NSString* startPage = ((CDVViewController *)self.viewController).startPage;
+        NSURL* URL = [self getStartPageURLForLocalPackage:deployedPackageMetadata.localPath];
+        if (![URL.path containsString:startPage]) {
+            return;
+        }
         [self redirectStartPageToURL: deployedPackageMetadata.localPath];
     }
 }
@@ -355,6 +360,7 @@ StatusReport* rollbackStatusReport = nil;
         [self handleUnconfirmedInstall:NO];
     }
 
+    [self navigateToLocalDeploymentIfExists];
     // handle both ON_NEXT_RESUME and ON_NEXT_RESTART - the application might have been killed after transitioning to the background
     if (pendingInstall && (pendingInstall.installMode == ON_NEXT_RESTART || pendingInstall.installMode == ON_NEXT_RESUME)) {
         [self markUpdate];

--- a/src/ios/CodePush.m
+++ b/src/ios/CodePush.m
@@ -355,7 +355,6 @@ StatusReport* rollbackStatusReport = nil;
         [self handleUnconfirmedInstall:NO];
     }
 
-    //[self navigateToLocalDeploymentIfExists];
     // handle both ON_NEXT_RESUME and ON_NEXT_RESTART - the application might have been killed after transitioning to the background
     if (pendingInstall && (pendingInstall.installMode == ON_NEXT_RESTART || pendingInstall.installMode == ON_NEXT_RESUME)) {
         [self markUpdate];

--- a/src/ios/CodePush.m
+++ b/src/ios/CodePush.m
@@ -355,7 +355,7 @@ StatusReport* rollbackStatusReport = nil;
         [self handleUnconfirmedInstall:NO];
     }
 
-    [self navigateToLocalDeploymentIfExists];
+    //[self navigateToLocalDeploymentIfExists];
     // handle both ON_NEXT_RESUME and ON_NEXT_RESTART - the application might have been killed after transitioning to the background
     if (pendingInstall && (pendingInstall.installMode == ON_NEXT_RESTART || pendingInstall.installMode == ON_NEXT_RESUME)) {
         [self markUpdate];


### PR DESCRIPTION
Currently, the plugin does not contemplate opening other index.html within a cordova application, only the main index.html

An example would be to open another html index from a plugin in cordova.  (swift)
`     
 let view = CDVViewController(nibName: nil, bundle: nil)
        view.wwwFolderName = "file://www"
        view.startPage = "mynewapp/index.html"
        view.modalPresentationStyle = .fullScreen
        let rootVIEW = UIApplication.shared.keyWindow?.rootViewController 
        rootVIEW?.presentedViewController?.dismiss(animated: false, completion: nil)
        rootVIEW?.present(view, animated: true, completion: nil)

`
So in that case your plugin will change the path to 
file://www/mynewapp/index.html and is NOT correct. because that file is not exist in that route. (plugin skip all the local server route, and for that is not working)

In the ionic weview plugin they calculate only one time  CDV_LOCAL_SERVER, but in this plugin every time that open one new application inside the base app.

 ̶*̶*̶T̶H̶I̶S̶ ̶P̶U̶L̶L̶ ̶I̶S̶ ̶N̶O̶T̶ ̶F̶O̶R̶ ̶M̶E̶R̶G̶E̶,̶ ̶T̶H̶I̶S̶ ̶S̶O̶L̶U̶T̶I̶O̶N̶ ̶W̶O̶R̶K̶S̶ ̶O̶N̶L̶Y̶ ̶F̶O̶R̶ ̶I̶N̶S̶T̶A̶L̶L̶ ̶A̶N̶D̶ ̶R̶E̶O̶L̶O̶A̶D̶ ̶T̶H̶E̶ ̶B̶A̶S̶E̶ ̶A̶P̶P̶ ̶B̶U̶T̶ ̶I̶S̶ ̶N̶O̶T̶ ̶A̶ ̶C̶L̶E̶A̶N̶ ̶S̶O̶L̶U̶T̶I̶O̶N̶,̶ ̶C̶H̶E̶C̶K̶I̶N̶G̶ ̶@̶"̶.̶a̶p̶p̶"̶ ̶a̶n̶d̶ ̶"̶@̶c̶o̶d̶e̶p̶u̶s̶h̶"̶ ̶T̶O̶ ̶C̶H̶E̶C̶K̶ ̶I̶F̶ ̶I̶S̶ ̶T̶H̶E̶ ̶B̶A̶S̶E̶ ̶A̶P̶P̶ ̶O̶R̶ ̶N̶O̶T̶ ̶I̶S̶ ̶N̶O̶T̶.̶*̶*̶ ̶ ̶
̶
̶*̶*̶T̶H̶I̶S̶ ̶S̶O̶L̶U̶T̶I̶O̶N̶ ̶F̶A̶I̶L̶S̶ ̶T̶O̶ ̶O̶P̶E̶N̶ ̶F̶I̶L̶E̶ ̶O̶N̶ ̶O̶T̶H̶E̶R̶'̶S̶ ̶P̶L̶U̶G̶I̶N̶S̶ ̶W̶H̶E̶N̶ ̶T̶H̶E̶ ̶P̶L̶U̶G̶I̶N̶ ̶I̶N̶S̶T̶A̶L̶L̶ ̶A̶ ̶N̶E̶W̶ ̶V̶E̶R̶S̶I̶O̶N̶*̶*̶

The function loadPluginRequest should be placed in the init step of this plugin and when plugin install new version should have same path not diferent one

**EDIT** 

Removing line --> navigateToLocalDeploymentIfExists in codepush.m file works fine now