### PR TITLE
Prevent error when publicKey or signature is an empty string

### DIFF
--- a/bin/www/localPackage.js
+++ b/bin/www/localPackage.js
@@ -140,13 +140,13 @@ var LocalPackage = (function (_super) {
                 return;
             }
             publicKey = publicKeyResult;
-            isSignatureVerificationEnabled = (publicKey !== null);
+            isSignatureVerificationEnabled = !!publicKey;
             _this.getSignatureFromUpdate(deploymentResult.deployDir, function (error, signature) {
                 if (error) {
                     installError && installError(new Error("Error reading signature from update. " + error));
                     return;
                 }
-                isSignatureAppearedInBundle = (signature !== null);
+                isSignatureAppearedInBundle = !!signature;
                 verify(isSignatureVerificationEnabled, isSignatureAppearedInBundle, publicKey, signature);
             });
         });


### PR DESCRIPTION
I was experiencing the error below
```
Error! Public key was provided...
```

But I've never put public/private key during deploy&update.

I figured out that Capacitor(successor of Cordova) returns empty string on public key request.
Empty string also means not providing public key, so I changed the code to cover that case