### PR TITLE
Prevent error when publicKey or signature is an empty string

### DIFF
--- a/bin/www/localPackage.js
+++ b/bin/www/localPackage.js
@@ -140,13 +140,13 @@ var LocalPackage = (function (_super) {
                 return;
             }
             publicKey = publicKeyResult;
-            isSignatureVerificationEnabled = (publicKey !== null);
+            isSignatureVerificationEnabled = !!publicKey;
             _this.getSignatureFromUpdate(deploymentResult.deployDir, function (error, signature) {
                 if (error) {
                     installError && installError(new Error("Error reading signature from update. " + error));
                     return;
                 }
-                isSignatureAppearedInBundle = (signature !== null);
+                isSignatureAppearedInBundle = !!signature;
                 verify(isSignatureVerificationEnabled, isSignatureAppearedInBundle, publicKey, signature);
             });
         });

--- a/www/localPackage.ts
+++ b/www/localPackage.ts
@@ -115,7 +115,7 @@ class LocalPackage extends Package implements ILocalPackage {
     }
 
     private verifyPackage(deploymentResult: DeploymentResult, installError: ErrorCallback, successCallback: SuccessCallback<void>): void {
-        
+
         var deployDir = deploymentResult.deployDir;
 
         var verificationFail: ErrorCallback = (error: Error) => {
@@ -129,7 +129,7 @@ class LocalPackage extends Package implements ILocalPackage {
                         this.verifySignature(deployDir, this.packageHash, publicKey, signature, verificationFail, successCallback);
                     });
                 } else {
-                    var errorMessage = 
+                    var errorMessage =
                     "Error! Public key was provided but there is no JWT signature within app bundle to verify. " +
                     "Possible reasons, why that might happen: \n" +
                     "1. You've been released CodePush bundle update using version of CodePush CLI that is not support code signing.\n" +
@@ -152,7 +152,7 @@ class LocalPackage extends Package implements ILocalPackage {
                     } else {
                         successCallback();
                     }
-                }          
+                }
             }
         };
 
@@ -172,7 +172,7 @@ class LocalPackage extends Package implements ILocalPackage {
             }
 
             publicKey = publicKeyResult;
-            isSignatureVerificationEnabled = (publicKey !== null);
+            isSignatureVerificationEnabled = !!publicKey;
 
             this.getSignatureFromUpdate(deploymentResult.deployDir, (error, signature) => {
                 if (error) {
@@ -180,7 +180,7 @@ class LocalPackage extends Package implements ILocalPackage {
                     return;
                 }
 
-                isSignatureAppearedInBundle = (signature !== null);
+                isSignatureAppearedInBundle = !!signature;
 
                 verify(isSignatureVerificationEnabled, isSignatureAppearedInBundle, publicKey, signature);
             });
@@ -219,7 +219,7 @@ class LocalPackage extends Package implements ILocalPackage {
                     callback(error, null);
                     return;
                 }
-                
+
                 callback(null, signature);
             });
         });


### PR DESCRIPTION
From https://github.com/microsoft/cordova-plugin-code-push/pull/631