### PR TITLE
Fix cordova-ios 6 issue with file:// requests being rejected

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -98,7 +98,10 @@
             <header-file src="src/ios/Utilities.h" />
             <source-file src="src/ios/Utilities.m" />
             <source-file src="src/ios/CDVWKWebViewEngine+CodePush.m" />
-
+            <source-file src="src/ios/WebViewShared.m" />
+            <source-file src="src/ios/WebViewShared.h" />
+            <source-file src="src/ios/CDVViewController+CodePush.m" />
+            
             <!-- JWT -->
             <source-file src="src/ios/JWT/Core/Algorithms/Base/CodePushJWTAlgorithmFactory.m" />
             <source-file src="src/ios/JWT/Core/Algorithms/Base/CodePushJWTAlgorithmNone.m" />

--- a/src/ios/CDVViewController+CodePush.m
+++ b/src/ios/CDVViewController+CodePush.m
@@ -40,7 +40,7 @@
      Note 1: self.webViewEngine loadRequest will be failing anyway but calling [webViewShared loadRequest] will hide it for user.
      Note 2: It affects only cordova-ios 6 apps
     */
-    if([Utilities cordova6OrGreater]) {
+    if([Utilities CDVWebViewEngineAvailable]) {
         WebViewShared* webViewShared = [WebViewShared getInstanceOrCreate:self.webViewEngine
                                                   andCommandDelegate:self.commandDelegate
                                                    andViewController:self];

--- a/src/ios/CDVViewController+CodePush.m
+++ b/src/ios/CDVViewController+CodePush.m
@@ -1,0 +1,81 @@
+#import <Cordova/CDVViewController.h>
+#import <objc/runtime.h>
+#import "WebViewShared.h"
+#import "Utilities.h"
+
+@interface CDVViewController (CodePush)
+- (NSURL*)appUrl; // Expose private method from original CDVViewController
+@end
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wincomplete-implementation"
+
+@implementation CDVViewController (CodePush)
+
+#pragma clang diagnostic pop
+
+- (void)viewDidLoad_codepush
+{
+    // Calls original viewDidLoad method from CDVViewController
+    [self viewDidLoad_codepush];
+    
+    /*
+     In original viewDid method from CDVViewController at the end it tries to open using something like self.webViewEngine loadRequest [self appUrl].
+     [self appUrl] is only resolves full path for startPage.
+     For example
+     
+     // CDVViewController.m
+     ...
+     // self.startPage is set somewhere to @"index.html";
+     
+     - (void)viewDidLoad {
+        ...
+         NSURL* url = [self appUrl]; //manipulates with self.startPage
+         //url is now @"file://HOSTNAME/path/to/index.html"
+     }
+     
+     It leads to WKWebView unable to load it because url prefixed with "file://" is rejected by web view for some reason.
+     In practice it means that after applying CodePush update and restarting app blank screen is appeared.
+     To workaround it [webViewShared loadRequest] is called after self.webViewEngine loadRequest is called in the original viewDidLoad method.
+     Note 1: self.webViewEngine loadRequest will be failing anyway but calling [webViewShared loadRequest] will hide it for user.
+     Note 2: It affects only cordova-ios 6 apps
+    */
+    if([Utilities cordova6OrGreater]) {
+        WebViewShared* webViewShared = [WebViewShared getInstanceOrCreate:self.webViewEngine
+                                                  andCommandDelegate:self.commandDelegate
+                                                   andViewController:self];
+        NSURL* url = [self appUrl];
+        [webViewShared loadRequest:[NSURLRequest requestWithURL:url]];
+    }
+}
+
+// Swizzling original viewDidLoad method
++ (void)load
+{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class class = [self class];
+
+        SEL originalSelector = @selector(viewDidLoad);
+        SEL swizzledSelector = @selector(viewDidLoad_codepush);
+
+        Method originalMethod = class_getInstanceMethod(class, originalSelector);
+        Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);
+
+        BOOL didAddMethod = class_addMethod(class,
+                                            originalSelector,
+                                            method_getImplementation(swizzledMethod),
+                                            method_getTypeEncoding(swizzledMethod));
+
+        if (didAddMethod) {
+            class_replaceMethod(class,
+                                swizzledSelector,
+                                method_getImplementation(originalMethod),
+                                method_getTypeEncoding(originalMethod));
+        } else {
+            method_exchangeImplementations(originalMethod, swizzledMethod);
+        }
+    });
+}
+
+@end

--- a/src/ios/CDVViewController+CodePush.m
+++ b/src/ios/CDVViewController+CodePush.m
@@ -20,7 +20,7 @@
     [self viewDidLoad_codepush];
     
     /*
-     In original viewDid method from CDVViewController at the end it tries to open using something like self.webViewEngine loadRequest [self appUrl].
+     In original viewDid method from CDVViewController at the end it tries to open start page using something like self.webViewEngine loadRequest [self appUrl].
      [self appUrl] is only resolves full path for startPage.
      For example
      

--- a/src/ios/CDVWKWebViewEngine+CodePush.m
+++ b/src/ios/CDVWKWebViewEngine+CodePush.m
@@ -25,7 +25,7 @@ NSString* lastLoadedURL = @"";
 // Fix bug related to unable WKWebView recovery after reinit with loaded codepush update
 - (void)webView:(WKWebView*)theWebView didFailNavigation:(WKNavigation*)navigation withError:(NSError*)error {
     // NSURLErrorFailingURLStringErrorKey is URL which caused a load to fail, if it's null then webView was terminated for some reason
-    if ([[error userInfo] objectForKey:NSURLErrorFailingURLStringErrorKey] == nil && [lastLoadedURL containsString:IdentifierCodePushPath]) {
+    if ([[error userInfo] objectForKey:NSURLErrorFailingURLStringErrorKey] == nil && [lastLoadedURL containsString:[WebViewShared getIdentifierCodePushPath]]) {
         NSLog(@"Failed to load webpage with error: %@", [error localizedDescription]);
         NSLog(@"Trying to reload request with url: %@", lastLoadedURL);
         // Manually loading codepush start page via loadRequest method of this category

--- a/src/ios/CDVWKWebViewEngine+CodePush.m
+++ b/src/ios/CDVWKWebViewEngine+CodePush.m
@@ -1,13 +1,12 @@
 #if defined(__has_include)
 #if __has_include("CDVWKWebViewEngine.h")
 
-#import <Cordova/NSDictionary+CordovaPreferences.h>
 #import "CDVWKWebViewEngine.h"
 #import "CodePush.h"
+#import "WebViewShared.h"
 
 @implementation CDVWKWebViewEngine (CodePush)
 
-NSString* const IdentifierCodePushPath = @"codepush/deploy/versions";
 NSString* lastLoadedURL = @"";
 
 #pragma clang diagnostic push
@@ -15,72 +14,10 @@ NSString* lastLoadedURL = @"";
 
 - (id)loadRequest:(NSURLRequest *)request {
     lastLoadedURL = request.URL.absoluteString;
-    NSURL *readAccessURL;
-
-    NSURL* bundleURL = [[NSBundle mainBundle] bundleURL];
-    if (![lastLoadedURL containsString:bundleURL.path] && ![lastLoadedURL containsString:IdentifierCodePushPath]) {
-        return [self loadPluginRequest:request];
-    }
-
-    if (request.URL.isFileURL) {
-        // All file URL requests should be handled with the setServerBasePath in case if it is Ionic app.
-        if ([CodePush hasIonicWebViewEngine: self]) {
-            NSString* specifiedServerPath = [CodePush getCurrentServerBasePath];
-            if (![specifiedServerPath containsString:IdentifierCodePushPath] || [request.URL.path containsString:IdentifierCodePushPath]) {
-                [CodePush setServerBasePath:request.URL.path webView: self];
-            }
-
-            return nil;
-        }
-
-        if ([request.URL.absoluteString containsString:IdentifierCodePushPath]) {
-            // If the app is attempting to load a CodePush update, then we can lock the WebView down to
-            // just the CodePush "versions" directory. This prevents non-CodePush assets from being accessible,
-            // while still allowing us to navigate to a future update, as well as to the binary if a rollback is needed.
-            NSString *libraryPath = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES)[0];
-            readAccessURL = [NSURL fileURLWithPathComponents:@[libraryPath, @"NoCloud", @"codepush", @"deploy", @"versions"]];
-        } else {
-            // In order to allow the WebView to be navigated from the app bundle to another location, we (for some
-            // entirely unknown reason) need to ensure that the "read access URL" is set to the parent of the bundle
-            // as opposed to the www folder, which is what the WKWebViewEngine would attempt to set it to by default.
-            // If we didn't set this, then the attempt to navigate from the bundle to a CodePush update would fail.
-            readAccessURL = [[[NSBundle mainBundle] bundleURL] URLByDeletingLastPathComponent];
-        }
-
-        return [(WKWebView*)self.engineWebView loadFileURL:request.URL allowingReadAccessToURL:readAccessURL];
-    } else {
-        return [(WKWebView*)self.engineWebView loadRequest: request];
-    }
-}
-
-- (id)loadPluginRequest:(NSURLRequest *)request {
-    if (request.URL.fileURL) {
-        NSDictionary* settings = self.commandDelegate.settings;
-        NSString *bind = [settings cordovaSettingForKey:@"Hostname"];
-        if(bind == nil){
-            bind = @"localhost";
-        }
-        NSString *scheme = [settings cordovaSettingForKey:@"iosScheme"];
-        if(scheme == nil || [scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"]  || [scheme isEqualToString:@"file"]){
-            scheme = @"ionic";
-        }
-        NSString *CDV_LOCAL_SERVER = [NSString stringWithFormat:@"%@://%@", scheme, bind];
-        
-        NSURL* startURL = [NSURL URLWithString:((CDVViewController *)self.viewController).startPage];
-        NSString* startFilePath = [self.commandDelegate pathForResource:[startURL path]];
-        NSURL *url = [[NSURL URLWithString:CDV_LOCAL_SERVER] URLByAppendingPathComponent:request.URL.path];
-        if ([request.URL.path isEqualToString:startFilePath]) {
-            url = [NSURL URLWithString:CDV_LOCAL_SERVER];
-        }
-        if(request.URL.query) {
-            url = [NSURL URLWithString:[@"?" stringByAppendingString:request.URL.query] relativeToURL:url];
-        }
-        if(request.URL.fragment) {
-            url = [NSURL URLWithString:[@"#" stringByAppendingString:request.URL.fragment] relativeToURL:url];
-        }
-        request = [NSURLRequest requestWithURL:url];
-    }
-    return [(WKWebView*)self.engineWebView loadRequest:request];
+    WebViewShared* webViewShared = [WebViewShared getInstanceOrCreate:self.webViewEngine
+                                                            andCommandDelegate:self.commandDelegate
+                                                             andViewController:self.viewController];
+    return [webViewShared loadRequest: request];
 }
 
 #pragma clang diagnostic pop

--- a/src/ios/CDVWKWebViewEngine+CodePush.m
+++ b/src/ios/CDVWKWebViewEngine+CodePush.m
@@ -2,7 +2,6 @@
 #if __has_include("CDVWKWebViewEngine.h")
 
 #import "CDVWKWebViewEngine.h"
-#import "CodePush.h"
 #import "WebViewShared.h"
 
 @implementation CDVWKWebViewEngine (CodePush)

--- a/src/ios/CDVWKWebViewEngine+CodePush.m
+++ b/src/ios/CDVWKWebViewEngine+CodePush.m
@@ -16,7 +16,7 @@ NSString* lastLoadedURL = @"";
     WebViewShared* webViewShared = [WebViewShared getInstanceOrCreate:self.webViewEngine
                                                             andCommandDelegate:self.commandDelegate
                                                              andViewController:self.viewController];
-    return [webViewShared loadRequest: request];
+    return [webViewShared loadRequest:request];
 }
 
 #pragma clang diagnostic pop

--- a/src/ios/CodePush.m
+++ b/src/ios/CodePush.m
@@ -11,6 +11,7 @@
 #import "StatusReport.h"
 #import "UpdateHashUtils.h"
 #import "CodePushJWT.h"
+#import "WebViewShared.h"
 
 @implementation CodePush
 
@@ -21,6 +22,7 @@ NSDate* lastResignedDate;
 NSString* const DeploymentKeyPreference = @"codepushdeploymentkey";
 NSString* const PublicKeyPreference = @"codepushpublickey";
 StatusReport* rollbackStatusReport = nil;
+WebViewShared* webViewShared = nil;
 
 - (void)getBinaryHash:(CDVInvokedUrlCommand *)command {
     [self.commandDelegate runInBackground:^{
@@ -351,6 +353,9 @@ StatusReport* rollbackStatusReport = nil;
 }
 
 - (void)pluginInitialize {
+    webViewShared = [WebViewShared getInstanceOrCreate:self.webViewEngine
+                                              andCommandDelegate:self.commandDelegate
+                                               andViewController:self.viewController];
     // register for "on resume", "on pause" notifications
     [self clearDeploymentsIfBinaryUpdated];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationWillEnterForeground) name:UIApplicationWillEnterForegroundNotification object:nil];
@@ -402,15 +407,20 @@ StatusReport* rollbackStatusReport = nil;
 }
 
 - (void)loadURL:(NSURL*)url {
+    // Fix file:// requests issues for cordova-ios 6+
+    if([Utilities cordova6OrGreater]) {
+        [webViewShared loadRequest:[NSURLRequest requestWithURL:url]];
+    } else {
     // In order to make use of the "modern" Cordova platform, while still
     // maintaining back-compat with Cordova iOS 3.9.0, we need to conditionally
     // use the WebViewEngine for performing navigations only if the host app
     // is running 4.0.0+, and fallback to directly using the WebView otherwise.
-#if (WK_WEB_VIEW_ONLY && defined(__CORDOVA_4_0_0)) || defined(__CORDOVA_4_0_0)
-    [self.webViewEngine loadRequest:[NSURLRequest requestWithURL:url]];
-#else
-    [(UIWebView*)self.webView loadRequest:[NSURLRequest requestWithURL:url]];
-#endif
+    #if (WK_WEB_VIEW_ONLY && defined(__CORDOVA_4_0_0)) || defined(__CORDOVA_4_0_0)
+        [self.webViewEngine loadRequest:[NSURLRequest requestWithURL:url]];
+    #else
+        [(UIWebView*)self.webView loadRequest:[NSURLRequest requestWithURL:url]];
+    #endif
+    }
 }
 
 + (Boolean) hasIonicWebViewEngine:(id<CDVWebViewEngineProtocol>) webViewEngine {

--- a/src/ios/CodePush.m
+++ b/src/ios/CodePush.m
@@ -408,7 +408,7 @@ WebViewShared* webViewShared = nil;
 
 - (void)loadURL:(NSURL*)url {
     // Fix file:// requests issues for cordova-ios 6+
-    if([Utilities cordova6OrGreater]) {
+    if([Utilities CDVWebViewEngineAvailable]) {
         [webViewShared loadRequest:[NSURLRequest requestWithURL:url]];
     } else {
         // In order to make use of the "modern" Cordova platform, while still

--- a/src/ios/CodePush.m
+++ b/src/ios/CodePush.m
@@ -411,15 +411,15 @@ WebViewShared* webViewShared = nil;
     if([Utilities cordova6OrGreater]) {
         [webViewShared loadRequest:[NSURLRequest requestWithURL:url]];
     } else {
-    // In order to make use of the "modern" Cordova platform, while still
-    // maintaining back-compat with Cordova iOS 3.9.0, we need to conditionally
-    // use the WebViewEngine for performing navigations only if the host app
-    // is running 4.0.0+, and fallback to directly using the WebView otherwise.
-    #if (WK_WEB_VIEW_ONLY && defined(__CORDOVA_4_0_0)) || defined(__CORDOVA_4_0_0)
-        [self.webViewEngine loadRequest:[NSURLRequest requestWithURL:url]];
-    #else
-        [(UIWebView*)self.webView loadRequest:[NSURLRequest requestWithURL:url]];
-    #endif
+        // In order to make use of the "modern" Cordova platform, while still
+        // maintaining back-compat with Cordova iOS 3.9.0, we need to conditionally
+        // use the WebViewEngine for performing navigations only if the host app
+        // is running 4.0.0+, and fallback to directly using the WebView otherwise.
+        #if (WK_WEB_VIEW_ONLY && defined(__CORDOVA_4_0_0)) || defined(__CORDOVA_4_0_0)
+            [self.webViewEngine loadRequest:[NSURLRequest requestWithURL:url]];
+        #else
+            [(UIWebView*)self.webView loadRequest:[NSURLRequest requestWithURL:url]];
+        #endif
     }
 }
 

--- a/src/ios/Utilities.h
+++ b/src/ios/Utilities.h
@@ -3,5 +3,6 @@
 + (NSString*)getApplicationVersion;
 + (NSString*)getApplicationTimestamp;
 + (NSDate*)getApplicationBuildTime;
++ (BOOL)cordova6OrGreater;
 
 @end

--- a/src/ios/Utilities.h
+++ b/src/ios/Utilities.h
@@ -3,6 +3,6 @@
 + (NSString*)getApplicationVersion;
 + (NSString*)getApplicationTimestamp;
 + (NSDate*)getApplicationBuildTime;
-+ (BOOL)cordova6OrGreater;
++ (BOOL)CDVWebViewEngineAvailable;
 
 @end

--- a/src/ios/Utilities.m
+++ b/src/ios/Utilities.m
@@ -24,6 +24,10 @@
     return fileDate;
 }
 
++ (BOOL)cordova6OrGreater{
+    return NSClassFromString(@"CDVWebViewEngine");
+}
+
 void CPLog(NSString *formatString, ...) {
     va_list args;
     va_start(args, formatString);

--- a/src/ios/Utilities.m
+++ b/src/ios/Utilities.m
@@ -2,6 +2,9 @@
 
 @implementation Utilities
 
+static BOOL CDVWebViewEngineChecked = NO;
+static BOOL CDVWebViewEngineExists = NO;
+
 + (NSString*)getApplicationVersion{
     return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
 }
@@ -24,8 +27,12 @@
     return fileDate;
 }
 
-+ (BOOL)cordova6OrGreater{
-    return NSClassFromString(@"CDVWebViewEngine");
++ (BOOL)CDVWebViewEngineAvailable{
+    if (!CDVWebViewEngineChecked) {
+        CDVWebViewEngineChecked = YES;
+        CDVWebViewEngineExists = NSClassFromString(@"CDVWebViewEngine") != nil;
+    }
+    return CDVWebViewEngineExists;
 }
 
 void CPLog(NSString *formatString, ...) {

--- a/src/ios/WebViewShared.h
+++ b/src/ios/WebViewShared.h
@@ -1,0 +1,15 @@
+#import <Cordova/CDVWebViewEngineProtocol.h>
+#import <Cordova/CDVCommandDelegate.h>
+
+@interface WebViewShared : NSObject
+
+@property id<CDVCommandDelegate> commandDelegate;
+@property id<CDVWebViewEngineProtocol> webViewEngine;
+@property UIViewController *viewController;
+
++ (id)getInstanceOrCreate:(id<CDVWebViewEngineProtocol>)webViewEngine andCommandDelegate:(id<CDVCommandDelegate>)commandDelegate andViewController:(UIViewController *)viewController;
+- (id)initWithWebViewEngine:(id<CDVWebViewEngineProtocol>)webViewEngine andCommandDelegate:(id<CDVCommandDelegate>)commandDelegate andViewController:(UIViewController *)viewController;
+- (id)loadRequest:(NSURLRequest *)request;
+- (id)loadIonicPluginRequest:(NSURLRequest *)request;
+
+@end

--- a/src/ios/WebViewShared.h
+++ b/src/ios/WebViewShared.h
@@ -8,6 +8,7 @@
 @property UIViewController *viewController;
 
 + (id)getInstanceOrCreate:(id<CDVWebViewEngineProtocol>)webViewEngine andCommandDelegate:(id<CDVCommandDelegate>)commandDelegate andViewController:(UIViewController *)viewController;
++ (NSString *)getIdentifierCodePushPath;
 - (id)initWithWebViewEngine:(id<CDVWebViewEngineProtocol>)webViewEngine andCommandDelegate:(id<CDVCommandDelegate>)commandDelegate andViewController:(UIViewController *)viewController;
 - (id)loadRequest:(NSURLRequest *)request;
 - (id)loadIonicPluginRequest:(NSURLRequest *)request;

--- a/src/ios/WebViewShared.m
+++ b/src/ios/WebViewShared.m
@@ -8,7 +8,6 @@
 id<CDVWebViewEngineProtocol> webViewEngine;
 id<CDVCommandDelegate> commandDelegate;
 UIViewController* viewController;
-NSString* const IdentifierCodePushPath = @"codepush/deploy/versions";
 
 + (id)getInstanceOrCreate:(id<CDVWebViewEngineProtocol>)webViewEngine andCommandDelegate:(id<CDVCommandDelegate>)commandDelegate andViewController:(UIViewController*)viewController {
     static WebViewShared* instance = nil;
@@ -19,6 +18,10 @@ NSString* const IdentifierCodePushPath = @"codepush/deploy/versions";
                                andViewController:viewController];
     });
     return instance;
+}
+
++ (NSString*)getIdentifierCodePushPath{
+    return @"codepush/deploy/versions";
 }
     
 - (id)initWithWebViewEngine:(id<CDVWebViewEngineProtocol>)webViewEngine andCommandDelegate:(id<CDVCommandDelegate>)commandDelegate andViewController:(UIViewController*)viewController {
@@ -34,10 +37,11 @@ NSString* const IdentifierCodePushPath = @"codepush/deploy/versions";
 
 - (id)loadRequest:(NSURLRequest *)request {
     NSString* lastLoadedURL = request.URL.absoluteString;
+    NSString* identifierCodePushPath = [WebViewShared getIdentifierCodePushPath];
     NSURL *readAccessURL;
 
     NSURL* bundleURL = [[NSBundle mainBundle] bundleURL];
-    if (![lastLoadedURL containsString:bundleURL.path] && ![lastLoadedURL containsString:IdentifierCodePushPath]) {
+    if (![lastLoadedURL containsString:bundleURL.path] && ![lastLoadedURL containsString:identifierCodePushPath]) {
         // Happens only for Ionic apps
         return [self loadIonicPluginRequest: request];
     }
@@ -46,14 +50,14 @@ NSString* const IdentifierCodePushPath = @"codepush/deploy/versions";
         // All file URL requests should be handled with the setServerBasePath in case if it is Ionic app.
         if ([CodePush hasIonicWebViewEngine: self.webViewEngine]) {
             NSString* specifiedServerPath = [CodePush getCurrentServerBasePath];
-            if (![specifiedServerPath containsString:IdentifierCodePushPath] || [request.URL.path containsString:IdentifierCodePushPath]) {
+            if (![specifiedServerPath containsString:identifierCodePushPath] || [request.URL.path containsString:identifierCodePushPath]) {
                 [CodePush setServerBasePath:request.URL.path webView: self.webViewEngine];
             }
 
             return nil;
         }
 
-        if ([request.URL.absoluteString containsString:IdentifierCodePushPath]) {
+        if ([request.URL.absoluteString containsString:identifierCodePushPath) {
             // If the app is attempting to load a CodePush update, then we can lock the WebView down to
             // just the CodePush "versions" directory. This prevents non-CodePush assets from being accessible,
             // while still allowing us to navigate to a future update, as well as to the binary if a rollback is needed.

--- a/src/ios/WebViewShared.m
+++ b/src/ios/WebViewShared.m
@@ -57,7 +57,7 @@ UIViewController* viewController;
             return nil;
         }
 
-        if ([request.URL.absoluteString containsString:identifierCodePushPath) {
+        if ([request.URL.absoluteString containsString:identifierCodePushPath]) {
             // If the app is attempting to load a CodePush update, then we can lock the WebView down to
             // just the CodePush "versions" directory. This prevents non-CodePush assets from being accessible,
             // while still allowing us to navigate to a future update, as well as to the binary if a rollback is needed.

--- a/src/ios/WebViewShared.m
+++ b/src/ios/WebViewShared.m
@@ -1,0 +1,106 @@
+#import <WebKit/WebKit.h>
+#import "WebViewShared.h"
+#import "CodePush.h"
+#import <Cordova/NSDictionary+CordovaPreferences.h>
+
+@implementation WebViewShared
+
+id<CDVWebViewEngineProtocol> webViewEngine;
+id<CDVCommandDelegate> commandDelegate;
+UIViewController* viewController;
+NSString* const IdentifierCodePushPath = @"codepush/deploy/versions";
+
++ (id)getInstanceOrCreate:(id<CDVWebViewEngineProtocol>)webViewEngine andCommandDelegate:(id<CDVCommandDelegate>)commandDelegate andViewController:(UIViewController*)viewController {
+    static WebViewShared* instance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        instance = [[self alloc] initWithWebViewEngine:webViewEngine
+                              andCommandDelegate:commandDelegate
+                               andViewController:viewController];
+    });
+    return instance;
+}
+    
+- (id)initWithWebViewEngine:(id<CDVWebViewEngineProtocol>)webViewEngine andCommandDelegate:(id<CDVCommandDelegate>)commandDelegate andViewController:(UIViewController*)viewController {
+    self = [super init];
+    if (self) {
+        _webViewEngine = webViewEngine;
+        _commandDelegate = commandDelegate;
+        _viewController = viewController;
+    }
+    
+    return self;
+}
+
+- (id)loadRequest:(NSURLRequest *)request {
+    NSString* lastLoadedURL = request.URL.absoluteString;
+    NSURL *readAccessURL;
+
+    NSURL* bundleURL = [[NSBundle mainBundle] bundleURL];
+    if (![lastLoadedURL containsString:bundleURL.path] && ![lastLoadedURL containsString:IdentifierCodePushPath]) {
+        // Happens only for Ionic apps
+        return [self loadIonicPluginRequest: request];
+    }
+
+    if (request.URL.isFileURL) {
+        // All file URL requests should be handled with the setServerBasePath in case if it is Ionic app.
+        if ([CodePush hasIonicWebViewEngine: self.webViewEngine]) {
+            NSString* specifiedServerPath = [CodePush getCurrentServerBasePath];
+            if (![specifiedServerPath containsString:IdentifierCodePushPath] || [request.URL.path containsString:IdentifierCodePushPath]) {
+                [CodePush setServerBasePath:request.URL.path webView: self.webViewEngine];
+            }
+
+            return nil;
+        }
+
+        if ([request.URL.absoluteString containsString:IdentifierCodePushPath]) {
+            // If the app is attempting to load a CodePush update, then we can lock the WebView down to
+            // just the CodePush "versions" directory. This prevents non-CodePush assets from being accessible,
+            // while still allowing us to navigate to a future update, as well as to the binary if a rollback is needed.
+            NSString *libraryPath = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES)[0];
+            readAccessURL = [NSURL fileURLWithPathComponents:@[libraryPath, @"NoCloud", @"codepush", @"deploy", @"versions"]];
+        } else {
+            // In order to allow the WebView to be navigated from the app bundle to another location, we (for some
+            // entirely unknown reason) need to ensure that the "read access URL" is set to the parent of the bundle
+            // as opposed to the www folder, which is what the WKWebViewEngine would attempt to set it to by default.
+            // If we didn't set this, then the attempt to navigate from the bundle to a CodePush update would fail.
+            readAccessURL = [[[NSBundle mainBundle] bundleURL] URLByDeletingLastPathComponent];
+        }
+
+        return [(WKWebView*)self.webViewEngine loadFileURL:request.URL allowingReadAccessToURL:readAccessURL];
+    } else {
+        return [(WKWebView*)self.webViewEngine loadRequest: request];
+    }
+}
+
+- (id)loadIonicPluginRequest:(NSURLRequest *)request {
+    if (request.URL.fileURL) {
+        NSDictionary* settings = self.commandDelegate.settings;
+        NSString *bind = [settings cordovaSettingForKey:@"Hostname"];
+        if(bind == nil){
+            bind = @"localhost";
+        }
+        NSString *scheme = [settings cordovaSettingForKey:@"iosScheme"];
+        if(scheme == nil || [scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"]  || [scheme isEqualToString:@"file"]){
+            scheme = @"ionic";
+        }
+        NSString *CDV_LOCAL_SERVER = [NSString stringWithFormat:@"%@://%@", scheme, bind];
+        
+        NSURL* startURL = [NSURL URLWithString:((CDVViewController *)self.viewController).startPage];
+        NSString* startFilePath = [self.commandDelegate pathForResource:[startURL path]];
+        NSURL *url = [[NSURL URLWithString:CDV_LOCAL_SERVER] URLByAppendingPathComponent:request.URL.path];
+        if ([request.URL.path isEqualToString:startFilePath]) {
+            url = [NSURL URLWithString:CDV_LOCAL_SERVER];
+        }
+        if(request.URL.query) {
+            url = [NSURL URLWithString:[@"?" stringByAppendingString:request.URL.query] relativeToURL:url];
+        }
+        if(request.URL.fragment) {
+            url = [NSURL URLWithString:[@"#" stringByAppendingString:request.URL.fragment] relativeToURL:url];
+        }
+        request = [NSURLRequest requestWithURL:url];
+    }
+    return [(WKWebView*)self.webViewEngine loadRequest:request];
+}
+
+@end

--- a/src/ios/WebViewShared.m
+++ b/src/ios/WebViewShared.m
@@ -43,15 +43,15 @@ UIViewController* viewController;
     NSURL* bundleURL = [[NSBundle mainBundle] bundleURL];
     if (![lastLoadedURL containsString:bundleURL.path] && ![lastLoadedURL containsString:identifierCodePushPath]) {
         // Happens only for Ionic apps
-        return [self loadIonicPluginRequest: request];
+        return [self loadIonicPluginRequest:request];
     }
 
     if (request.URL.isFileURL) {
         // All file URL requests should be handled with the setServerBasePath in case if it is Ionic app.
-        if ([CodePush hasIonicWebViewEngine: self.webViewEngine]) {
+        if ([CodePush hasIonicWebViewEngine:self.webViewEngine]) {
             NSString* specifiedServerPath = [CodePush getCurrentServerBasePath];
             if (![specifiedServerPath containsString:identifierCodePushPath] || [request.URL.path containsString:identifierCodePushPath]) {
-                [CodePush setServerBasePath:request.URL.path webView: self.webViewEngine];
+                [CodePush setServerBasePath:request.URL.path webView:self.webViewEngine];
             }
 
             return nil;
@@ -73,7 +73,7 @@ UIViewController* viewController;
 
         return [(WKWebView*)self.webViewEngine loadFileURL:request.URL allowingReadAccessToURL:readAccessURL];
     } else {
-        return [(WKWebView*)self.webViewEngine loadRequest: request];
+        return [(WKWebView*)self.webViewEngine loadRequest:request];
     }
 }
 


### PR DESCRIPTION
Related issue #624.

This PR is similar to #635 but makes a fix more clear way.

## Problem

Starting with cordova-ios 6 [`UIWebView` is replaced with `WKWebView` and also `WKURLSchemeHandler` is introduced](https://cordova.apache.org/announcements/2020/06/01/cordova-ios-release-6.0.0.html). 
If add these parameters to `config.xml`
```xml
<preference name="scheme" value="app" />
<preference name="hostname" value="localhost" />
```
then `file://` requests are rejected by `WKURLSchemeHandler` which causes app to become blank after applying CodePush update.

There was already [a fix](https://github.com/microsoft/cordova-plugin-code-push/blob/master/src/ios/CDVWKWebViewEngine%2BCodePush.m#L56-L84) for that in `CDVWKWebViewEngine+CodePush.m` but it was applied only for the case when 
* cordova-ios 4, 5 was used
* Additional [cordova-plugin-wkwebview-engine](https://github.com/apache/cordova-plugin-wkwebview-engine) package was installed and configured within application (it was supposed to be used as a temporary solution for cordova-ios 4, 5 to let developers use `WKWebView` unless official support is added)

This PR applies the fix for cordova-ios 6 as well.

## Implementation specifics

* `loadRequest` and `loadPluginRequest ` methods was extracted from `CDVWKWebViewEngine+CodePush.m` into new `WebViewShared` class. Now both `CodePush.m` and `CDVWKWebViewEngine+CodePush.m` shares the same fix logic written in one place.
* This class works as a [thread-safe singleton](https://developer.apple.com/documentation/dispatch/1447169-dispatch_once) to avoid it's possible re-initialization during the CodePush plugin life cycle.
* To avoid showing blank screen after applying the update and restarting application a workaround was implemented (please see comment [here](https://github.com/microsoft/cordova-plugin-code-push/pull/655/files#diff-bd9033e830cd10b9ac2ba5cec7f741b1R23-R41) for the explanation)
