### PR TITLE
Fix cordova-ios v6 issues and remove UIWebView support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ In order to ensure that your end users always have a functioning version of your
 Cordova 5.0.0+ is fully supported, along with the following associated platforms:
 
 * Android ([cordova-android](https://github.com/apache/cordova-android) 4.0.0+) - *Including CrossWalk!* *Note: Only on TLS 1.2 compatible devices*
-* iOS ([cordova-ios](https://github.com/apache/cordova-ios) 3.9.0+) - *Note: In order to use CodePush along with the [`cordova-plugin-wkwebview-engine`](https://github.com/apache/cordova-plugin-wkwebview-engine) plugin, you need to install `v1.5.1-beta+` version of `cordova-plugin-code-push`, which includes full support for apps using either WebView.*
+* iOS ([cordova-ios](https://github.com/apache/cordova-ios) 3.9.0+) - please see notes below.
+
+> Note: Starting with v2.0.0 `cordova-plugin-code-push` doesn't support apps using UIWebView due to [Apple officially deprecated it and discourage developers from using it](https://developer.apple.com/news/?id=12232019b). Prior versions of the plugin still support UIWebView but be aware that the App Store will no longer accept new apps using UIWebView as of April 2020 and app updates using UIWebView as of December 2020.
+
+> Note: In order to use CodePush along with the [`cordova-plugin-wkwebview-engine`](https://github.com/apache/cordova-plugin-wkwebview-engine) plugin, you need to install `v1.5.1-beta+` version of `cordova-plugin-code-push`, which includes full support for apps using either WebView. Please see [Using WKWebView](#using-wkwebview) section for more information of how to confiure your app to use `cordova-plugin-wkwebview-engine`.
 
 To check which versions of each Cordova platform you are currently using, you can run the following command and inspect the `Installed platforms` list:
 
@@ -123,10 +127,15 @@ With the CodePush plugin installed, configure your app to use it via the followi
 
 You are now ready to use the plugin in the application code. See the [sample applications](/samples) for examples and the API documentation for more details.
 
-*NOTE: There is a possibility to specify WebView engine on the plugin build phase. By default UIWebView engine is used. You can force plugin to use WKWebView by adding this iOS specific preference:*
-```xml
-<preference name="WKWebViewOnly" value="true" />
-```
+### Using WKWebView
+
+For cordova-ios v4-v5 there is a possibility to specify WebView engine on the plugin build phase. By default UIWebView engine is used. To use WKWebView engine please do the following:
+
+* Install [cordova-plugin-wkwebview-engine](https://github.com/apache/cordova-plugin-wkwebview-engine#installation)
+* [Configure your app](https://github.com/apache/cordova-plugin-wkwebview-engine#required-permissions) to use WKWebView
+
+> Note: `cordova-plugin-wkwebview-engine` is just a workaround for cordova-ios v4-v5 users to be able to use WKWebView in their apps to avoid stop accepting updates via AppStore as of December 2020.
+Cordova-ios v6+ has full support for native WKWebView and doesn't require `cordova-plugin-wkwebview-engine`.
 
 ## Plugin Usage
 

--- a/src/ios/CodePush.m
+++ b/src/ios/CodePush.m
@@ -403,11 +403,12 @@ StatusReport* rollbackStatusReport = nil;
 }
 
 - (void)loadURL:(NSURL*)url {
-    BOOL atLeastCordova4 = NO;
-    #if defined(__CORDOVA_4_0_0)
-        atLeastCordova4 = YES;
-    #endif
-    if([Utilities CDVWebViewEngineAvailable] || (WK_WEB_VIEW_ONLY && atLeastCordova4))
+#if WK_WEB_VIEW_ONLY && defined(__CORDOVA_4_0_0)
+    BOOL useUiWebView = NO;
+#else
+    BOOL useUiWebView = YES;
+#endif
+    if([Utilities CDVWebViewEngineAvailable] || !useUiWebView)
     {
         [self.webViewEngine loadRequest:[NSURLRequest requestWithURL:url]];
     } else {

--- a/src/ios/CodePushReportingManager.m
+++ b/src/ios/CodePushReportingManager.m
@@ -34,7 +34,6 @@ NSString* const LastVersionPreferenceLabelOrAppVersionKey = @"LAST_VERSION_LABEL
 
         /* JS function to call: window.codePush.reportStatus(status: number, label: String, appVersion: String, deploymentKey: String) */
         NSString* script = [NSString stringWithFormat:@"document.addEventListener(\"deviceready\", function () { window.codePush.reportStatus(%i, %@, %@, %@, %@, %@); });", (int)statusReport.status, labelParameter, appVersionParameter, deploymentKeyParameter, lastVersionLabelOrAppVersionParameter, lastVersionDeploymentKeyParameter];
-        #if WK_WEB_VIEW_ONLY
         if ([webView respondsToSelector:@selector(evaluateJavaScript:completionHandler:)]) {
             // The WKWebView requires JS evaluation to occur on the main
             // thread starting with iOS11, so ensure that we dispatch to it before executing.
@@ -42,21 +41,6 @@ NSString* const LastVersionPreferenceLabelOrAppVersionKey = @"LAST_VERSION_LABEL
                 [webView performSelector:@selector(evaluateJavaScript:completionHandler:) withObject:script withObject: NULL];
             });
         }
-        #else
-        if ([webView respondsToSelector:@selector(evaluateJavaScript:completionHandler:)]) {
-            // The WKWebView requires JS evaluation to occur on the main
-            // thread starting with iOS11, so ensure that we dispatch to it before executing.
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [webView performSelector:@selector(evaluateJavaScript:completionHandler:) withObject:script withObject: NULL];
-            });
-        } else if ([webView isKindOfClass:[UIWebView class]]) {
-            // The UIWebView requires JS evaluation to occur on the main
-            // thread, so ensure that we dispatch to it before executing.
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [(UIWebView*)webView stringByEvaluatingJavaScriptFromString:script];
-            });
-        }
-        #endif
     }
 }
 

--- a/src/ios/Utilities.h
+++ b/src/ios/Utilities.h
@@ -3,5 +3,6 @@
 + (NSString*)getApplicationVersion;
 + (NSString*)getApplicationTimestamp;
 + (NSDate*)getApplicationBuildTime;
++ (BOOL)CDVWebViewEngineAvailable;
 
 @end

--- a/src/ios/Utilities.m
+++ b/src/ios/Utilities.m
@@ -2,6 +2,8 @@
 
 @implementation Utilities
 
+static NSNumber* CDVWebViewEngineExists = nil;
+
 + (NSString*)getApplicationVersion{
     return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
 }
@@ -22,6 +24,14 @@
     NSDictionary *executableAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:appPlistPath error:nil];
     NSDate *fileDate = [executableAttributes objectForKey:@"NSFileModificationDate"];
     return fileDate;
+}
+
++ (BOOL)CDVWebViewEngineAvailable{
+    if(CDVWebViewEngineExists == nil) {
+        BOOL value = NSClassFromString(@"CDVWebViewEngine") != nil;
+        CDVWebViewEngineExists = [NSNumber numberWithBool:value];
+    }
+    return [CDVWebViewEngineExists boolValue];
 }
 
 void CPLog(NSString *formatString, ...) {


### PR DESCRIPTION
Related issue #624.

What this PR does:

* Starting with cordova-ios 6 [`UIWebView` is replaced with `WKWebView` and also `WKURLSchemeHandler` is introduced](https://cordova.apache.org/announcements/2020/06/01/cordova-ios-release-6.0.0.html) which allow users to specify app scheme to avoid `file://` requests (that causes CORS issues). Previously Code Push update was loaded on WebView using `file://` requests, but now if app scheme is configured plugin will be using it to load the updated app page.

* Apple completely [drops support for UIWebView as of December 2020](https://developer.apple.com/news/?id=12232019b). PR removes support for UIWebView as well.