### PR TITLE
Add binaryUpdateCallback to checkForUpdate & sync methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,12 +240,12 @@ Additionally, the following objects and enums are also exposed globally as part 
 ### codePush.checkForUpdate
 
 ```javascript
-codePush.checkForUpdate(onSuccess, onError?, deploymentKey?: String);
+codePush.checkForUpdate(onSuccess, onError?, deploymentKey?, onBinaryUpdate?);
 ```
 
 Queries the CodePush service to see whether the configured app deployment has an update available. By default, it will use the deployment key that is configured in your `config.xml` file, but you can override that by specifying a value via the optional `deploymentKey` parameter. This can be useful when you want to dynamically "redirect" a user to a specific deployment, such as allowing "Early access" via an easter egg or a user setting switch.
 
-When the update check completes, it will trigger the `onUpdateCheck` callback with one of two possible values:
+When the update check completes, it will trigger the `onSuccess` callback with one of two possible values:
 
 1. `null` if there is no update available. This occurs in the following scenarios:
 
@@ -276,6 +276,8 @@ codePush.checkForUpdate(function (update) {
     }
 });
 ```
+
+- __onBinaryUpdate__: Optional callback that is invoked when there is an update available that is targeting a newer binary version than you are currently running.
 
 ### codePush.getCurrentPackage
 
@@ -381,7 +383,7 @@ Immediately restarts the app. This method is for advanced scenarios, and is prim
 ### codePush.sync
 
 ```javascript
-codePush.sync(syncCallback?, syncOptions?, downloadProgress?, syncErrback?);
+codePush.sync(syncCallback?, syncOptions?, downloadProgress?, syncErrback?, onBinaryUpdate?);
 ```
 
 Synchronizes your app's code and images with the latest release to the configured deployment. Unlike the `checkForUpdate` method, which simply checks for the presence of an update, and let's you control what to do next, `sync` handles the update check, download and installation experience for you.
@@ -419,6 +421,10 @@ While the sync method tries to make it easy to perform silent and active updates
     - __totalBytes__ *(Number)* - The total number of bytes expected to be received for this update (i.e. the size of the set of files which changed from the previous release).
 
     - __receivedBytes__ *(Number)* - The number of bytes downloaded thus far, which can be used to track download progress.
+
+- __syncErrback__: Optional callback that is invoked in the event of an error. The callback takes one error parameter, containing the details of the error.
+
+- __onBinaryUpdate__: Optional callback that is invoked when there is an update available that is targeting a newer binary version than you are currently running.
 
 #### SyncOptions
 

--- a/bin/www/codePush.js
+++ b/bin/www/codePush.js
@@ -82,7 +82,7 @@ var CodePush = (function () {
             }
         });
     };
-    CodePush.prototype.checkForUpdate = function (querySuccess, queryError, deploymentKey) {
+    CodePush.prototype.checkForUpdate = function (querySuccess, queryError, deploymentKey, binaryUpdateCallback) {
         try {
             var callback = function (error, remotePackageOrUpdateNotification) {
                 if (error) {
@@ -96,6 +96,7 @@ var CodePush = (function () {
                     if (remotePackageOrUpdateNotification) {
                         if (remotePackageOrUpdateNotification.updateAppVersion) {
                             CodePushUtil.logMessage("An update is available, but it is targeting a newer binary version than you are currently running.");
+                            binaryUpdateCallback && binaryUpdateCallback(remotePackageOrUpdateNotification);
                             appUpToDate();
                         }
                         else {
@@ -160,7 +161,7 @@ var CodePush = (function () {
             CodePushUtil.invokeErrorCallback(new Error("An error occurred while querying for updates." + CodePushUtil.getErrorMessage(e)), queryError);
         }
     };
-    CodePush.prototype.sync = function (syncCallback, syncOptions, downloadProgress, syncErrback) {
+    CodePush.prototype.sync = function (syncCallback, syncOptions, downloadProgress, syncErrback, binaryUpdateCallback) {
         if (CodePush.SyncInProgress) {
             CodePushUtil.logMessage("Sync already in progress.");
             syncCallback && syncCallback(SyncStatus.IN_PROGRESS);
@@ -183,10 +184,10 @@ var CodePush = (function () {
                 syncCallback && syncCallback(result);
             };
             CodePush.SyncInProgress = true;
-            this.syncInternal(syncCallbackAndUpdateSyncInProgress, syncOptions, downloadProgress);
+            this.syncInternal(syncCallbackAndUpdateSyncInProgress, syncOptions, downloadProgress, binaryUpdateCallback);
         }
     };
-    CodePush.prototype.syncInternal = function (syncCallback, syncOptions, downloadProgress) {
+    CodePush.prototype.syncInternal = function (syncCallback, syncOptions, downloadProgress, onBinaryUpdate) {
         if (!syncOptions) {
             syncOptions = this.getDefaultSyncOptions();
         }
@@ -276,7 +277,7 @@ var CodePush = (function () {
             }
         };
         syncCallback && syncCallback(null, SyncStatus.CHECKING_FOR_UPDATE);
-        window.codePush.checkForUpdate(onUpdate, onError, syncOptions.deploymentKey);
+        window.codePush.checkForUpdate(onUpdate, onError, syncOptions.deploymentKey, onBinaryUpdate);
     };
     CodePush.prototype.getDefaultSyncOptions = function () {
         if (!CodePush.DefaultSyncOptions) {

--- a/typings/codePush.d.ts
+++ b/typings/codePush.d.ts
@@ -263,8 +263,9 @@ interface CodePushCordovaPlugin {
      *                     A null package means the application is up to date for the current native application version.
      * @param queryError Optional callback invoked in case of an error.
      * @param deploymentKey Optional deployment key that overrides the config.xml setting.
+     * @param binaryUpdateCallback Optional callback invoked when there is an update available, but it is targeting a newer binary version than you are currently running.
      */
-    checkForUpdate(querySuccess: SuccessCallback<IRemotePackage>, queryError?: ErrorCallback, deploymentKey?: string): void;
+    checkForUpdate(querySuccess: SuccessCallback<IRemotePackage>, queryError?: ErrorCallback, deploymentKey?: string, binaryUpdateCallback?: SuccessCallback<NativeUpdateNotification>): void;
 
     /**
      * Notifies the plugin that the update operation succeeded and that the application is ready.
@@ -301,9 +302,10 @@ interface CodePushCordovaPlugin {
      *                     The callback will be called only once, and the possible statuses are defined by the SyncStatus enum.
      * @param syncOptions Optional SyncOptions parameter configuring the behavior of the sync operation.
      * @param downloadProgress Optional callback invoked during the download process. It is called several times with one DownloadProgress parameter.
-     *
+     * @param syncErrback Optional errback invoked if an error occurs. The callback will be called only once
+     * @param binaryUpdateCallback Optional callback invoked when there is an update available, but it is targeting a newer binary version than you are currently running.
      */
-    sync(syncCallback?: SuccessCallback<SyncStatus>, syncOptions?: SyncOptions, downloadProgress?: SuccessCallback<DownloadProgress>): void;
+    sync(syncCallback?: SuccessCallback<SyncStatus>, syncOptions?: SyncOptions, downloadProgress?: SuccessCallback<DownloadProgress>, syncErrback?: ErrorCallback, binaryUpdateCallback?: SuccessCallback<NativeUpdateNotification>): void;
 }
 
 /**


### PR DESCRIPTION
This PR resolves #260.

As per https://github.com/microsoft/cordova-plugin-code-push/issues/260#issuecomment-311580943 this PR adds an additional callback to codePush.sync & checkForUpdate methods in a similar vein as react-native-code-push.

All the changes are purely additive, so no breaking changes. This does mean the syncCallback is still called with status UP_TO_DATE (directly after the newly added `binaryUpdateCallback` is called).

The binaryUpdateCallback is called with a NativeUpdateNotification object. Unfortunately this object doesn't contain a lot of useful info (only the binary target as `appVersion`). Other RemotePackage properties, such as isMandatory for example, are missing. To change/improve this, would require making changes to the (parent) `code-push` repo, specifically around [this line](https://github.com/microsoft/code-push/blob/e35c9e44aa96fa344754c05a930d26d806c227b6/src/script/acquisition-sdk.ts#L127). This may be considered as further action.