### PR TITLE
Fix code push dependency "cordova-plugin-advanced-http" AFNewtworking overriding

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -10,7 +10,7 @@
         <dependency id="cordova-plugin-dialogs" version=">=1.1.1" />
         <dependency id="cordova-plugin-device" version=">=1.1.0" />
         <dependency id="cordova-plugin-file" version=">=6.0.1" />
-        <dependency id="cordova-plugin-advanced-http" url="https://github.com/meiram-tr/cordova-plugin-advanced-http" />
+        <dependency id="cordova-plugin-advanced-http" url="https://github.com/meiram-tr/cordova-plugin-advanced-http.git#c2a0317b8f52469293c89c7ea4d1fb51a1545d70" />
         <dependency id="cordova-plugin-zip" version=">=3.1.0" />
 
         <js-module src="bin/www/codePush.js" name="codePush">

--- a/plugin.xml
+++ b/plugin.xml
@@ -10,7 +10,7 @@
         <dependency id="cordova-plugin-dialogs" version=">=1.1.1" />
         <dependency id="cordova-plugin-device" version=">=1.1.0" />
         <dependency id="cordova-plugin-file" version=">=6.0.1" />
-        <dependency id="cordova-plugin-advanced-http" version=">=2.2.0" />
+        <dependency id="cordova-plugin-advanced-http" url="https://github.com/meiram-tr/cordova-plugin-advanced-http" />
         <dependency id="cordova-plugin-zip" version=">=3.1.0" />
 
         <js-module src="bin/www/codePush.js" name="codePush">


### PR DESCRIPTION
when installing cordova code push plugin, it install a dependency plugin "cordova-plugin-advanced-http". The "cordova-plugin-advanced-http" is using a local copy of AFNetworking with manual changes. when this plugin is playing together with other dependency that depends on https://cocoapods.org/pods/AFNetworking version 4.0 and above this plugin overides the real AFNetworking library files. I have created a fork of the "cordova-plugin-advanced-http" and fix the issue.
In order to make both library and this plugin together I replaced AFNewtworking files and classes names (in this code) to prevent conflicts with the real pod library. else it causes the apps to crash.